### PR TITLE
Allow initialization of GroupConsumer from EARLIEST_OFFSET.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,5 +200,6 @@ You can also write your own assignment strategy function and provide it as `fn` 
 * `sessionTimeout` - session timeout in ms, min 6000, max 30000, defaults to 15000
 * `heartbeatTimeout` - delay between heartbeat requests in ms, defaults to 1000
 * `retentionTime` - offset retention time in ms, defaults to 1 day (24 * 3600 * 1000)
+* `initFromEarliest` - Boolean - Initialize the consumer positions to the earliest offset if true. False/default is to start from the latest offset.
 
 

--- a/lib/base_consumer.js
+++ b/lib/base_consumer.js
@@ -69,7 +69,7 @@ BaseConsumer.prototype._fetch = function() {
             if(p.error){
                 if(p.error.code === 'OffsetOutOfRange'){ // update partition offset to latest
                     Kafka.warn('Updating offset to latest because of OffsetOutOfRange error for', p.topic + ':' + p.partition);
-                    return self._offset(s.leader, p.topic, p.partition, null, self.initFromEarliest ? Kafka.EARLIEST_OFFSET : Kafka.LATEST_OFFSET).then(function (offset) {
+                    return self._offset(s.leader, p.topic, p.partition, null, self.options.initFromEarliest ? Kafka.EARLIEST_OFFSET : Kafka.LATEST_OFFSET).then(function (offset) {
                         s.offset = offset;
                     });
                 } else if (/UnknownTopicOrPartition|NotLeaderForPartition|LeaderNotAvailable/.test(p.error.code)) {
@@ -112,7 +112,7 @@ BaseConsumer.prototype._offset = function(leader, topic, partition, time) {
         topicName: topic,
         partitions: [{
             partition: partition,
-            time: time || (self.initFromEarliest ? Kafka.EARLIEST_OFFSET : Kafka.LATEST_OFFSET), // the latest (next) offset by default
+            time: time || (self.options.initFromEarliest ? Kafka.EARLIEST_OFFSET : Kafka.LATEST_OFFSET), // the latest (next) offset by default
             maxNumberOfOffsets: 1
         }]
     }];

--- a/lib/base_consumer.js
+++ b/lib/base_consumer.js
@@ -12,7 +12,8 @@ function BaseConsumer (options){
         timeout: 100, // client timeout for produce and fetch requests
         idleTimeout: 1000, // timeout between fetch requests
         minBytes: 1,
-        maxBytes: 1024 * 1024
+        maxBytes: 1024 * 1024,
+        initFromEarliest: false
     });
 
     this.client = new Client(this.options);
@@ -68,7 +69,7 @@ BaseConsumer.prototype._fetch = function() {
             if(p.error){
                 if(p.error.code === 'OffsetOutOfRange'){ // update partition offset to latest
                     Kafka.warn('Updating offset to latest because of OffsetOutOfRange error for', p.topic + ':' + p.partition);
-                    return self._offset(s.leader, p.topic, p.partition, null, Kafka.LATEST_OFFSET).then(function (offset) {
+                    return self._offset(s.leader, p.topic, p.partition, null, self.initFromEarliest ? Kafka.EARLIEST_OFFSET : Kafka.LATEST_OFFSET).then(function (offset) {
                         s.offset = offset;
                     });
                 } else if (/UnknownTopicOrPartition|NotLeaderForPartition|LeaderNotAvailable/.test(p.error.code)) {
@@ -111,7 +112,7 @@ BaseConsumer.prototype._offset = function(leader, topic, partition, time) {
         topicName: topic,
         partitions: [{
             partition: partition,
-            time: time || Kafka.LATEST_OFFSET, // the latest (next) offset by default
+            time: time || (self.initFromEarliest ? Kafka.EARLIEST_OFFSET : Kafka.LATEST_OFFSET), // the latest (next) offset by default
             maxNumberOfOffsets: 1
         }]
     }];

--- a/lib/group_consumer.js
+++ b/lib/group_consumer.js
@@ -12,7 +12,8 @@ function GroupConsumer (options){
         groupId: 'no-kafka-group-v0.9',
         sessionTimeout: 15000, // min 6000, max 30000
         heartbeatTimeout: 1000,
-        retentionTime: 24 * 3600 * 1000 // offset retention time, in ms
+        retentionTime: 24 * 3600 * 1000, // offset retention time, in ms
+        initFromEarliest: false
     });
 
     BaseConsumer.call(this, this.options);
@@ -23,7 +24,7 @@ function GroupConsumer (options){
     this.memberId = null;
     this.generationId = 0;
     this.members = null;
-
+    
     this.strategy = null; // current strategy assigned by group coordinator
 }
 
@@ -316,7 +317,7 @@ GroupConsumer.prototype._updateSubscriptions = function(partitionAssignment) {
                 if(p.error || p.offset < 0){
                     // subscribe to latest partition offset
                     return self.subscribe(p.topic, p.partition, {
-                        time: Kafka.LATEST_OFFSET
+                        time: self.initFromEarliest ? Kafka.EARLIEST_OFFSET : Kafka.LATEST_OFFSET
                     });
                 }
                 return self.subscribe(p.topic, p.partition, {

--- a/lib/group_consumer.js
+++ b/lib/group_consumer.js
@@ -317,7 +317,7 @@ GroupConsumer.prototype._updateSubscriptions = function(partitionAssignment) {
                 if(p.error || p.offset < 0){
                     // subscribe to latest partition offset
                     return self.subscribe(p.topic, p.partition, {
-                        time: self.initFromEarliest ? Kafka.EARLIEST_OFFSET : Kafka.LATEST_OFFSET
+                        time: self.options.initFromEarliest ? Kafka.EARLIEST_OFFSET : Kafka.LATEST_OFFSET
                     });
                 }
                 return self.subscribe(p.topic, p.partition, {


### PR DESCRIPTION
Hello,

I've added in a basic option that permits users of the library to specify EARLIEST_OFFSET as their initial position when adding a new GroupConsumer. This addresses #1 I'd raised earlier today. The change is to add an initFromEarliest option that is used to toggle between Kafka.EARLIEST_OFFSET and Kafka.LATEST_OFFSET since otherwise you cannot retroactively add a GroupConsumer of old messages.

The change defaults to the original behaviour when the parameter is not specified, and will not introduce a change to clients that are not expecting it.

Cheers,
-Steve