### PR TITLE
Control starting offset with a custom function

### DIFF
--- a/lib/group_consumer.js
+++ b/lib/group_consumer.js
@@ -12,7 +12,8 @@ function GroupConsumer (options){
         groupId: 'no-kafka-group-v0.9',
         sessionTimeout: 15000, // min 6000, max 30000
         heartbeatTimeout: 1000,
-        retentionTime: 24 * 3600 * 1000 // offset retention time, in ms
+        retentionTime: 24 * 3600 * 1000, // offset retention time, in ms
+        offsetFn: null
     });
 
     BaseConsumer.call(this, this.options);
@@ -221,6 +222,7 @@ GroupConsumer.prototype._rejoin = function() {
                     return _tryRebalance(++attempt);
                 });
             }
+            throw err;
         });
     }
 
@@ -313,6 +315,13 @@ GroupConsumer.prototype._updateSubscriptions = function(partitionAssignment) {
     return self.client.updateMetadata().then(function () {
         return self.fetchOffset(offsetRequests).then(function (result) {
             return Promise.map(result, function (p) {
+                if(typeof self.options.offsetFn === 'function'){
+                    return Promise.try(self.options.offsetFn, p).then(function (_offset) {
+                        return self.subscribe(p.topic, p.partition, {
+                            offset: _offset
+                        });
+                    });
+                }
                 if(p.error || p.offset < 0){
                     // subscribe to latest partition offset
                     return self.subscribe(p.topic, p.partition, {


### PR DESCRIPTION
Another option for #1 

With the new GroupConsumer option `offsetFn` you can change the starting offset on initial startup or any group rebalance. Function receives committed offset object `{topic, partition, offset, metadata, error}`:

Always (even on group rebalance) use EARLIEST offset:
```javascript
var consumer = new Kafka.GroupConsumer({
    offsetFn: function (r) {
        return consumer.offset(r.topic, r.partition, Kafka.EARLIEST_OFFSET);
    }
});
```

Use EARLIEST only once per running consumer instance (or when there is no committed offset):
```javascript
var _cache = {};
var consumer = new Kafka.GroupConsumer({
    offsetFn: function (r) {
        if(!_cache[r.topic + ':' + r.partition] || r.error || r.offset < 0){
            return consumer.offset(r.topic, r.partition, Kafka.EARLIEST_OFFSET).tap(function () {
                _cache[r.topic + ':' + r.partition] = true;
            });
        }
        return r.offset + 1; // use next offset
    }
});
```