### PR TITLE
Don't call .resolve() on empty work queue.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -164,7 +164,10 @@ Connection.prototype._receive = function (data) {
 
     this.readBufPos = 0;
 
-    this.queue.shift().resolve(data.slice(4, length + 4));
+    var next = this.queue.shift();
+    if (next) {
+      next.resolve(data.slice(4, length + 4));
+    }
 
     if (data.length > 4 + length) {
         this._receive(data.slice(length + 4));


### PR DESCRIPTION
When shutting down mid-receive, a .resolve() might be called on the head of an empty work queue. This change adds a null-check before the resolve, to ensure this does not occur. It addresses GH issue #6 