### PR TITLE
Producer partitioner option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ return producer.init().then(function(){
 * `timeout` - timeout in ms for produce request
 * `clientId` - ID of this client, defaults to 'no-kafka-client'
 * `connectionString` - comma delimited list of initial brokers list, defaults to '127.0.0.1:9092'
+* `partitioner` - function used to determine topic partition for message. If message already specifies a partition, the partitioner won't be used. The partitioner function receives 3 arguments: the topic name, an array with partition ids (e.g. ['0', '1']), and the message (useful to partition by key, etc.).
 
 ## SimpleConsumer
 

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -11,6 +11,11 @@ function Producer(options) {
         timeout: 100
     });
 
+    if (options.hasOwnProperty('partitioner') && typeof options.partitioner !== 'function') {
+        throw new Error('Partitioner must be a function');
+    }
+
+    this.partitioner = options.partitioner;
     this.client = new Client(this.options);
 }
 
@@ -32,9 +37,12 @@ Producer.prototype._prepareProduceRequest = function (data) {
         if (typeof d.topic !== 'string' || d.topic === '') {
             throw new Error('Missing or wrong topic field');
         }
-        if (typeof d.partition !== 'number' || d.partition < 0) {
+        if (self.partitioner && !d.hasOwnProperty('partition')) {
+            d.partition = self.partitioner(d.topic, Object.keys(self.client.topicMetadata[d.topic]), d.message);
+        } else if (typeof d.partition !== 'number' || d.partition < 0) {
             throw new Error('Missing or wrong partition field');
         }
+
         return self.client.findLeader(d.topic, d.partition, true).then(function (leader) {
             d.leader = leader;
         });


### PR DESCRIPTION
This allows to pass a partitioner function to a producer that will be called to determine the topic partition of every message.

Example:

    function randomPartitioner(partitions) {
        return partitions[Math.floor(Math.random() * partitions.length)];
    };
    
    var producer = new Kafka.Producer({
        partitioner: randomPartitioner
    });

@oleksiyk would you be ok with me adding 2-3 (random, cyclic, keyed) built-in partitioners similar to the consumer assignment strategies?