### PR TITLE
Consumer no emitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ before_install:
   - wget http://www.us.apache.org/dist/kafka/0.9.0.0/kafka_2.11-0.9.0.0.tgz -O kafka.tgz
   - mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1
   - nohup bash -c "cd kafka && bin/zookeeper-server-start.sh config/zookeeper.properties &"
-  - sleep 3
+  - sleep 10
   - nohup bash -c "cd kafka && bin/kafka-server-start.sh config/server.properties &"
-  - sleep 7
+  - sleep 10
   - kafka/bin/kafka-topics.sh --zookeeper 127.0.0.1:2181 --create --topic kafka-test-topic --partitions 3 --replication-factor 1
 
 after_script:

--- a/lib/base_consumer.js
+++ b/lib/base_consumer.js
@@ -62,19 +62,7 @@ BaseConsumer.prototype._fetch = function () {
                     return null; // already unsubscribed while we were polling
                 }
                 if (p.error) {
-                    if (p.error.code === 'OffsetOutOfRange') { // update partition offset to latest
-                        self.client.warn('Updating offset because of OffsetOutOfRange error for', p.topic + ':' + p.partition);
-                        return self._offset(s.leader, p.topic, p.partition, null, self.options.recoveryOffset).then(function (offset) {
-                            s.offset = offset;
-                        });
-                    } else if (/UnknownTopicOrPartition|NotLeaderForPartition|LeaderNotAvailable/.test(p.error.code)) {
-                        self.client.debug('Received', p.error.code, 'error for', p.topic + ':' + p.partition);
-                        return self._updateSubscription(p.topic, p.partition);
-                    } else if (p.error instanceof errors.NoKafkaConnectionError) {
-                        self.client.debug('Received connection error for', p.topic + ':' + p.partition);
-                        return self._updateSubscription(p.topic, p.partition);
-                    }
-                    self.client.error(p.topic + ':' + p.partition, p.error);
+                    return self._partitionError(p.error, p.topic, p.partition);
                 } else if (p.messageSet.length) {
                     s.paused = true;
                     s.handler(p.messageSet, p.topic, p.partition, p.highwaterMarkOffset)
@@ -104,6 +92,26 @@ BaseConsumer.prototype._fetch = function () {
             });
         }
     });
+};
+
+BaseConsumer.prototype._partitionError = function (err, topic, partition) {
+    var self = this;
+
+    var s = self.subscriptions[topic + ':' + partition];
+
+    if (err.code === 'OffsetOutOfRange') { // update partition offset to options.recoveryOffset
+        self.client.warn('Updating offset because of OffsetOutOfRange error for', topic + ':' + partition);
+        return self._offset(s.leader, topic, partition, null, self.options.recoveryOffset).then(function (offset) {
+            s.offset = offset;
+        });
+    } else if (/UnknownTopicOrPartition|NotLeaderForPartition|LeaderNotAvailable/.test(err.code)) {
+        self.client.debug('Received', err.code, 'error for', topic + ':' + partition);
+        return self._updateSubscription(topic, partition);
+    } else if (err instanceof errors.NoKafkaConnectionError) {
+        self.client.debug('Received connection error for', topic + ':' + partition);
+        return self._updateSubscription(topic, partition);
+    }
+    self.client.error(topic + ':' + partition, err);
 };
 
 BaseConsumer.prototype._updateSubscription = function (topic, partition) {

--- a/lib/base_consumer.js
+++ b/lib/base_consumer.js
@@ -3,8 +3,6 @@
 var Promise = require('bluebird');
 var _       = require('lodash');
 var Client  = require('./client');
-var events  = require('events');
-var util    = require('util');
 var Kafka   = require('./index');
 var errors  = require('./errors');
 
@@ -22,13 +20,9 @@ function BaseConsumer(options) {
     this.subscriptions = {};
 
     this._finished = false;
-
-    events.EventEmitter.call(this);
 }
 
 module.exports = BaseConsumer;
-
-util.inherits(BaseConsumer, events.EventEmitter);
 
 /**
  * Initialize BaseConsumer
@@ -36,79 +30,80 @@ util.inherits(BaseConsumer, events.EventEmitter);
  * @return {Prommise}
  */
 BaseConsumer.prototype.init = function () {
+    this._fetchPromise = this._fetch();
     return this.client.init();
 };
 
 BaseConsumer.prototype._fetch = function () {
-    var self = this, immediate = false, data;
+    var self = this;
 
-    if (self._fetch_running) {
-        return;
-    }
+    return Promise.try(function () {
+        var data = _(self.subscriptions).reject({ paused: true }).values().groupBy('leader').mapValues(function (v) {
+            return _(v)
+                .groupBy('topic')
+                .map(function (p, t) {
+                    return {
+                        topicName: t,
+                        partitions: p
+                    };
+                })
+                .value();
+        }).value();
 
-    data = _(self.subscriptions).values().groupBy('leader').mapValues(function (v) {
-        return _(v)
-            .groupBy('topic')
-            .map(function (p, t) {
-                return {
-                    topicName: t,
-                    partitions: p
-                };
-            })
-            .value();
-    }).value();
-
-    if (_.isEmpty(data)) {
-        self._fetch_running = false;
-        return;
-    }
-
-    self._fetch_running = self.client.fetchRequest(data).then(function (results) {
-        if (self._finished) { return null; }
-        return Promise.map(results, function (p) {
-            var s = self.subscriptions[p.topic + ':' + p.partition];
-            if (!s) {
-                return null; // already unsubscribed while we were polling
-            }
-            if (p.error) {
-                if (p.error.code === 'OffsetOutOfRange') { // update partition offset to latest
-                    self.client.warn('Updating offset because of OffsetOutOfRange error for', p.topic + ':' + p.partition);
-                    return self._offset(s.leader, p.topic, p.partition, null, self.options.recoveryOffset).then(function (offset) {
-                        s.offset = offset;
-                    });
-                } else if (/UnknownTopicOrPartition|NotLeaderForPartition|LeaderNotAvailable/.test(p.error.code)) {
-                    self.client.debug('Received', p.error.code, 'error for', p.topic + ':' + p.partition);
-                    return self._updateSubscription(p.topic, p.partition);
-                } else if (p.error instanceof errors.NoKafkaConnectionError) {
-                    self.client.debug('Received connection error for', p.topic + ':' + p.partition);
-                    return self._updateSubscription(p.topic, p.partition);
-                }
-                self.client.error(p.topic + ':' + p.partition, p.error);
-            } else if (p.messageSet.length) {
-                s.offset = _.last(p.messageSet).offset + 1; // advance offset position
-                if (s.offset < p.highwaterMarkOffset) { // more messages available
-                    immediate = true;
-                }
-                self.emit('data', p.messageSet, p.topic, p.partition);
-            }
+        if (_.isEmpty(data)) {
             return null;
+        }
+
+        return self.client.fetchRequest(data).then(function (results) {
+            if (self._finished) { return null; }
+            return Promise.map(results, function (p) {
+                var s = self.subscriptions[p.topic + ':' + p.partition];
+                if (!s) {
+                    return null; // already unsubscribed while we were polling
+                }
+                if (p.error) {
+                    if (p.error.code === 'OffsetOutOfRange') { // update partition offset to latest
+                        self.client.warn('Updating offset because of OffsetOutOfRange error for', p.topic + ':' + p.partition);
+                        return self._offset(s.leader, p.topic, p.partition, null, self.options.recoveryOffset).then(function (offset) {
+                            s.offset = offset;
+                        });
+                    } else if (/UnknownTopicOrPartition|NotLeaderForPartition|LeaderNotAvailable/.test(p.error.code)) {
+                        self.client.debug('Received', p.error.code, 'error for', p.topic + ':' + p.partition);
+                        return self._updateSubscription(p.topic, p.partition);
+                    } else if (p.error instanceof errors.NoKafkaConnectionError) {
+                        self.client.debug('Received connection error for', p.topic + ':' + p.partition);
+                        return self._updateSubscription(p.topic, p.partition);
+                    }
+                    self.client.error(p.topic + ':' + p.partition, p.error);
+                } else if (p.messageSet.length) {
+                    s.paused = true;
+                    s.handler(p.messageSet, p.topic, p.partition, p.highwaterMarkOffset)
+                    .catch(function (err) {
+                        self.client.warn('Handler for', p.topic + ':' + p.partition, 'failed with', err);
+                    })
+                    .finally(function () {
+                        s.paused = false;
+                        s.offset = _.last(p.messageSet).offset + 1; // advance offset position
+                    });
+                }
+                return null;
+            });
         });
     })
     .catch(function (err) {
-        if (self._finished) { return; }
-        self.client.error(err);
+        if (!self._finished) {
+            self.client.error(err);
+        }
     })
-    .tap(function () {
-        var schedule;
-        if (self._finished) { return; }
-        schedule = immediate ? process.nextTick : _.partialRight(setTimeout, self.options.idleTimeout);
-        schedule(function () {
-            self._fetch_running = false;
-            self._fetch();
-        });
+    .then(function () {
+        if (!self._finished) {
+            return Promise.delay(self.options.idleTimeout).then(function () {
+                if (!self._finished) {
+                    return self._fetch();
+                }
+            });
+        }
     });
-
-    return;
 };
 
 BaseConsumer.prototype._updateSubscription = function (topic, partition) {
@@ -117,7 +112,7 @@ BaseConsumer.prototype._updateSubscription = function (topic, partition) {
     return self.client.updateMetadata().then(function () {
         var s = self.subscriptions[topic + ':' + partition];
 
-        return self.subscribe(topic, partition, s.offset ? { offset: s.offset } : s.options)
+        return self.subscribe(topic, partition, s.offset ? { offset: s.offset } : s.options, s.handler)
         .catch({ code: 'LeaderNotAvailable' }, function () {}) // ignore and try again on next fetch
         .catch(function (err) {
             self.client.error('Failed to re-subscribe to', topic + ':' + partition, err);
@@ -168,15 +163,22 @@ BaseConsumer.prototype.offset = function (topic, partition, time) {
 /**
  * Subscribe to topic/partition
  * @param  {String} topic
- * @param  {Number} partition
- * @param  {Object} options { maxBytes, offset, time }
+ * @param  {Number} [partition]
+ * @param  {Object} [options] { maxBytes, offset, time }
+ * @param  {Function} handler
  * @return {Promise}
  */
-BaseConsumer.prototype.subscribe = function (topic, partition, options) {
+BaseConsumer.prototype.subscribe = function (topic, partition, options, handler) {
     var self = this;
 
-    partition = partition || 0;
-    options = options || {};
+    if (typeof partition === 'function') {
+        handler = partition;
+        partition = 0;
+        options = {};
+    } else if (typeof options === 'function') {
+        handler = options;
+        options = {};
+    }
 
     function _subscribe(leader, _offset) {
         self.client.debug('Subscribed to', topic + ':' + partition);
@@ -185,12 +187,15 @@ BaseConsumer.prototype.subscribe = function (topic, partition, options) {
             partition: partition,
             offset: _offset,
             leader: leader,
-            maxBytes: options.maxBytes || self.options.maxBytes
+            maxBytes: options.maxBytes || self.options.maxBytes,
+            handler: handler
         };
         return _offset;
     }
 
     return self.client.findLeader(topic, partition).then(function (leader) {
+        handler = Promise.method(handler);
+
         if (options.offset >= 0) {
             return _subscribe(leader, options.offset);
         }
@@ -204,13 +209,9 @@ BaseConsumer.prototype.subscribe = function (topic, partition, options) {
             topic: topic,
             partition: partition,
             options: options,
-            leader: -1
+            leader: -1,
+            handler: handler
         };
-    })
-    .tap(function () {
-        process.nextTick(function () {
-            self._fetch();
-        });
     });
 };
 
@@ -226,11 +227,19 @@ BaseConsumer.prototype.unsubscribe = function (topic, partition) {
 
     partition = partition || 0;
 
-    return new Promise(function (resolve, reject) {
-        if (self.subscriptions[topic + ':' + partition]) {
-            delete self.subscriptions[topic + ':' + partition];
-            return resolve();
-        }
-        reject(new Error('Not subscribed to', topic + ':' + partition));
+    return new Promise(function (resolve) {
+        delete self.subscriptions[topic + ':' + partition];
+        return resolve();
+    });
+};
+
+BaseConsumer.prototype.end = function () {
+    var self = this;
+
+    self._finished = true;
+    self.subscriptions = {};
+
+    return self._fetchPromise.then(function () {
+        return self.client.end();
     });
 };

--- a/lib/group_consumer.js
+++ b/lib/group_consumer.js
@@ -34,7 +34,7 @@ util.inherits(GroupConsumer, BaseConsumer);
 /**
  * Initialize GroupConsumer
  *
- * @param  {Array|Object} strategies [{strategy, subscriptions, metadata, fn}]
+ * @param  {Array|Object} strategies [{strategy, subscriptions, metadata, fn, handler}]
  * @return {Promise}
  */
 GroupConsumer.prototype.init = function (strategies) {
@@ -50,6 +50,9 @@ GroupConsumer.prototype.init = function (strategies) {
         }
 
         strategies.forEach(function (s) {
+            if (typeof s.handler !== 'function') {
+                throw new Error('Strategy ' + s.strategy + ' is missing data handler');
+            }
             if (typeof s.fn !== 'function') {
                 s.fn = Kafka.RoundRobinAssignment;
             }
@@ -62,7 +65,7 @@ GroupConsumer.prototype.init = function (strategies) {
 
         return self._fullRejoin()
         .tap(function () {
-            self._heartbeat(); // start sending heartbeats
+            self._heartbeatPromise = self._heartbeat(); // start sending heartbeats
         });
     });
 };
@@ -208,22 +211,23 @@ GroupConsumer.prototype._heartbeat = function () {
 
     return self.client.heartbeatRequest(self.options.groupId, self.memberId, self.generationId)
     .catch({ code: 'RebalanceInProgress' }, function () {
-        if (self._finished) { return null; }
         self.client.log('Rejoining group on RebalanceInProgress');
         return self._rejoin();
     })
     .catch(function (err) {
-        if (self._finished) { return null; }
         self.client.error('Sending heartbeat failed: ', err);
         return self._fullRejoin().catch(function (_err) {
             self.client.error(_err);
         });
     })
     .tap(function () {
-        if (self._finished) { return; }
-        setTimeout(function () {
-            self._heartbeat();
-        }, self.options.heartbeatTimeout);
+        if (!self._finished) {
+            return Promise.delay(self.options.heartbeatTimeout).then(function () {
+                if (!self._finished) {
+                    return self._heartbeat();
+                }
+            });
+        }
     });
 };
 
@@ -238,8 +242,11 @@ GroupConsumer.prototype.end = function () {
     self._finished = true;
     self.subscriptions = {};
 
-    return self.client.leaveGroupRequest(self.options.groupId, self.memberId).then(function () {
-        return self.client.end();
+    return self._heartbeatPromise.then(function () {
+        return self.client.leaveGroupRequest(self.options.groupId, self.memberId);
+    })
+    .then(function () {
+        return BaseConsumer.prototype.end.call(self);
     });
 };
 
@@ -280,7 +287,8 @@ GroupConsumer.prototype.fetchOffset = function (commits) {
 };
 
 GroupConsumer.prototype._updateSubscriptions = function (partitionAssignment) {
-    var self = this, offsetRequests = [];
+    var self = this, offsetRequests = [],
+        handler = self.strategies[self.strategy].handler;
 
     if (_.isEmpty(partitionAssignment)) {
         return self.client.warn('No partition assignment received');
@@ -304,11 +312,11 @@ GroupConsumer.prototype._updateSubscriptions = function (partitionAssignment) {
                     if (p.error || p.offset < 0) {
                         return self.subscribe(p.topic, p.partition, {
                             time: self.options.startingOffset
-                        });
+                        }, handler);
                     }
                     return self.subscribe(p.topic, p.partition, {
                         offset: p.offset + 1
-                    });
+                    }, handler);
                 }())
                 .catch(function (err) {
                     self.client.error('Failed to subscribe to', p.topic + ':' + p.partition, err);

--- a/lib/simple_consumer.js
+++ b/lib/simple_consumer.js
@@ -85,4 +85,3 @@ SimpleConsumer.prototype.fetchOffset = function (commits) {
         return self.client.offsetFetchRequestV0(self.options.groupId, data);
     });
 };
-

--- a/lib/simple_consumer.js
+++ b/lib/simple_consumer.js
@@ -86,16 +86,3 @@ SimpleConsumer.prototype.fetchOffset = function (commits) {
     });
 };
 
-/**
- * Unsubscribe all topics and close all connections
- *
- * @return {Promise}
- */
-SimpleConsumer.prototype.end = function () {
-    var self = this;
-
-    self.subscriptions = {};
-    self._finished = true;
-
-    return self.client.end();
-};

--- a/test/02.simple_consumer.js
+++ b/test/02.simple_consumer.js
@@ -11,7 +11,7 @@ var _       = require('lodash');
 var producer = new Kafka.Producer({ requiredAcks: 1, clientId: 'producer' });
 var consumer = new Kafka.SimpleConsumer({ idleTimeout: 100, clientId: 'simple-consumer' });
 
-var dataListenerSpy = sinon.spy(function () {});
+var dataHandlerSpy = sinon.spy(function () {});
 
 var maxBytesTestMessagesSize;
 
@@ -20,10 +20,7 @@ describe('SimpleConsumer', function () {
         return Promise.all([
             producer.init(),
             consumer.init()
-        ])
-        .then(function () {
-            consumer.on('data', dataListenerSpy);
-        });
+        ]);
     });
 
     after(function () {
@@ -45,7 +42,7 @@ describe('SimpleConsumer', function () {
     });
 
     it('should receive new messages', function () {
-        return consumer.subscribe('kafka-test-topic', 0).then(function () {
+        return consumer.subscribe('kafka-test-topic', 0, dataHandlerSpy).then(function () {
             return producer.send({
                 topic: 'kafka-test-topic',
                 partition: 0,
@@ -55,20 +52,23 @@ describe('SimpleConsumer', function () {
         .delay(100)
         .then(function () {
             /* jshint expr: true */
-            dataListenerSpy.should.have.been.called; // eslint-disable-line
-            dataListenerSpy.lastCall.args[0].should.be.an('array').and.have.length(1);
-            dataListenerSpy.lastCall.args[1].should.be.a('string', 'kafka-test-topic');
-            dataListenerSpy.lastCall.args[2].should.be.a('number', 0);
+            dataHandlerSpy.should.have.been.called; // eslint-disable-line
+            dataHandlerSpy.lastCall.args[0].should.be.an('array').and.have.length(1);
+            dataHandlerSpy.lastCall.args[1].should.be.a('string');
+            dataHandlerSpy.lastCall.args[1].should.be.eql('kafka-test-topic');
+            dataHandlerSpy.lastCall.args[2].should.be.a('number');
+            dataHandlerSpy.lastCall.args[2].should.be.eql(0);
+            dataHandlerSpy.lastCall.args[3].should.be.a('number');
 
-            dataListenerSpy.lastCall.args[0][0].should.be.an('object');
-            dataListenerSpy.lastCall.args[0][0].should.have.property('message').that.is.an('object');
-            dataListenerSpy.lastCall.args[0][0].message.should.have.property('value');
-            dataListenerSpy.lastCall.args[0][0].message.value.toString('utf8').should.be.eql('p00');
+            dataHandlerSpy.lastCall.args[0][0].should.be.an('object');
+            dataHandlerSpy.lastCall.args[0][0].should.have.property('message').that.is.an('object');
+            dataHandlerSpy.lastCall.args[0][0].message.should.have.property('value');
+            dataHandlerSpy.lastCall.args[0][0].message.value.toString('utf8').should.be.eql('p00');
         });
     });
 
     it('should correctly encode/decode utf8 string message value', function () {
-        dataListenerSpy.reset();
+        dataHandlerSpy.reset();
         return producer.send({
             topic: 'kafka-test-topic',
             partition: 0,
@@ -77,15 +77,17 @@ describe('SimpleConsumer', function () {
         .delay(100)
         .then(function () {
             /* jshint expr: true */
-            dataListenerSpy.should.have.been.called; // eslint-disable-line
-            dataListenerSpy.lastCall.args[0].should.be.an('array').and.have.length(1);
-            dataListenerSpy.lastCall.args[1].should.be.a('string', 'kafka-test-topic');
-            dataListenerSpy.lastCall.args[2].should.be.a('number', 0);
+            dataHandlerSpy.should.have.been.called; // eslint-disable-line
+            dataHandlerSpy.lastCall.args[0].should.be.an('array').and.have.length(1);
+            dataHandlerSpy.lastCall.args[1].should.be.a('string');
+            dataHandlerSpy.lastCall.args[1].should.be.eql('kafka-test-topic');
+            dataHandlerSpy.lastCall.args[2].should.be.a('number');
+            dataHandlerSpy.lastCall.args[2].should.be.eql(0);
 
-            dataListenerSpy.lastCall.args[0][0].should.be.an('object');
-            dataListenerSpy.lastCall.args[0][0].should.have.property('message').that.is.an('object');
-            dataListenerSpy.lastCall.args[0][0].message.should.have.property('value');
-            dataListenerSpy.lastCall.args[0][0].message.value.toString('utf8').should.be.eql('人人生而自由，在尊嚴和權利上一律平等。');
+            dataHandlerSpy.lastCall.args[0][0].should.be.an('object');
+            dataHandlerSpy.lastCall.args[0][0].should.have.property('message').that.is.an('object');
+            dataHandlerSpy.lastCall.args[0][0].message.should.have.property('value');
+            dataHandlerSpy.lastCall.args[0][0].message.value.toString('utf8').should.be.eql('人人生而自由，在尊嚴和權利上一律平等。');
         });
     });
 
@@ -97,7 +99,7 @@ describe('SimpleConsumer', function () {
 
     it('should receive messages from specified offset', function () {
         return consumer.unsubscribe('kafka-test-topic', 0).then(function () {
-            dataListenerSpy.reset();
+            dataHandlerSpy.reset();
             return producer.send([{
                 topic: 'kafka-test-topic',
                 partition: 0,
@@ -111,16 +113,16 @@ describe('SimpleConsumer', function () {
         .delay(100)
         .then(function () {
             return consumer.offset('kafka-test-topic', 0).then(function (offset) {
-                return consumer.subscribe('kafka-test-topic', 0, { offset: offset - 2 })
+                return consumer.subscribe('kafka-test-topic', 0, { offset: offset - 2 }, dataHandlerSpy)
                 .delay(100) // consumer sleep timeout
                 .then(function () {
                     /* jshint expr: true */
-                    dataListenerSpy.should.have.been.called; // eslint-disable-line
-                    dataListenerSpy.lastCall.args[0].should.be.an('array').and.have.length(2);
-                    dataListenerSpy.lastCall.args[0][0].message.value.toString('utf8').should.be.eql('p000');
-                    dataListenerSpy.lastCall.args[0][1].message.value.toString('utf8').should.be.eql('p001');
+                    dataHandlerSpy.should.have.been.called; // eslint-disable-line
+                    dataHandlerSpy.lastCall.args[0].should.be.an('array').and.have.length(2);
+                    dataHandlerSpy.lastCall.args[0][0].message.value.toString('utf8').should.be.eql('p000');
+                    dataHandlerSpy.lastCall.args[0][1].message.value.toString('utf8').should.be.eql('p001');
                     // save for next test
-                    maxBytesTestMessagesSize = dataListenerSpy.lastCall.args[0][0].messageSize + dataListenerSpy.lastCall.args[0][1].messageSize;
+                    maxBytesTestMessagesSize = dataHandlerSpy.lastCall.args[0][0].messageSize + dataHandlerSpy.lastCall.args[0][1].messageSize;
                 });
             });
         });
@@ -128,64 +130,58 @@ describe('SimpleConsumer', function () {
 
     it('should receive messages in maxBytes batches', function () {
         return consumer.unsubscribe('kafka-test-topic', 0).then(function () {
-            dataListenerSpy.reset();
+            dataHandlerSpy.reset();
             return consumer.offset('kafka-test-topic', 0).then(function (offset) {
                 // ask for maxBytes that is only 1 byte less then required for both last messages
                 var maxBytes = 2 * (8 + 4) + maxBytesTestMessagesSize - 1;
-                return consumer.subscribe('kafka-test-topic', 0, { offset: offset - 2, maxBytes: maxBytes })
+                return consumer.subscribe('kafka-test-topic', 0, { offset: offset - 2, maxBytes: maxBytes }, dataHandlerSpy)
                 .delay(200)
                 .then(function () {
                     /* jshint expr: true */
-                    dataListenerSpy.should.have.been.calledTwice; // eslint-disable-line
-                    dataListenerSpy.getCall(0).args[0].should.be.an('array').and.have.length(1);
-                    dataListenerSpy.getCall(1).args[0].should.be.an('array').and.have.length(1);
-                    dataListenerSpy.getCall(0).args[0][0].message.value.toString('utf8').should.be.eql('p000');
-                    dataListenerSpy.getCall(1).args[0][0].message.value.toString('utf8').should.be.eql('p001');
+                    dataHandlerSpy.should.have.been.calledTwice; // eslint-disable-line
+                    dataHandlerSpy.getCall(0).args[0].should.be.an('array').and.have.length(1);
+                    dataHandlerSpy.getCall(1).args[0].should.be.an('array').and.have.length(1);
+                    dataHandlerSpy.getCall(0).args[0][0].message.value.toString('utf8').should.be.eql('p000');
+                    dataHandlerSpy.getCall(1).args[0][0].message.value.toString('utf8').should.be.eql('p001');
                 });
             });
         });
     });
 
     it('should be able to commit offsets', function () {
-        return Promise.all([
-            consumer.subscribe('kafka-test-topic', 0),
-            consumer.subscribe('kafka-test-topic', 1)
-        ])
-        .then(function () {
-            return consumer.commitOffset([
-                {
-                    topic: 'kafka-test-topic',
-                    partition: 0,
-                    offset: 1,
-                    metadata: 'm1'
-                },
-                {
-                    topic: 'kafka-test-topic',
-                    partition: 1,
-                    offset: 2,
-                    metadata: 'm2'
-                },
-                {
-                    topic: 'kafka-test-topic',
-                    partition: 2,
-                    offset: 3,
-                    metadata: 'm3'
-                }
-            ]).then(function (result) {
-                result.should.be.an('array').that.has.length(3);
-                result[0].should.be.an('object');
-                result[1].should.be.an('object');
-                result[2].should.be.an('object');
-                result[0].should.have.property('topic', 'kafka-test-topic');
-                result[1].should.have.property('topic', 'kafka-test-topic');
-                result[2].should.have.property('topic', 'kafka-test-topic');
-                result[0].should.have.property('partition').that.is.a('number');
-                result[1].should.have.property('partition').that.is.a('number');
-                result[2].should.have.property('partition').that.is.a('number');
-                result[0].should.have.property('error', null);
-                result[1].should.have.property('error', null);
-                result[2].should.have.property('error', null);
-            });
+        return consumer.commitOffset([
+            {
+                topic: 'kafka-test-topic',
+                partition: 0,
+                offset: 1,
+                metadata: 'm1'
+            },
+            {
+                topic: 'kafka-test-topic',
+                partition: 1,
+                offset: 2,
+                metadata: 'm2'
+            },
+            {
+                topic: 'kafka-test-topic',
+                partition: 2,
+                offset: 3,
+                metadata: 'm3'
+            }
+        ]).then(function (result) {
+            result.should.be.an('array').that.has.length(3);
+            result[0].should.be.an('object');
+            result[1].should.be.an('object');
+            result[2].should.be.an('object');
+            result[0].should.have.property('topic', 'kafka-test-topic');
+            result[1].should.have.property('topic', 'kafka-test-topic');
+            result[2].should.have.property('topic', 'kafka-test-topic');
+            result[0].should.have.property('partition').that.is.a('number');
+            result[1].should.have.property('partition').that.is.a('number');
+            result[2].should.have.property('partition').that.is.a('number');
+            result[0].should.have.property('error', null);
+            result[1].should.have.property('error', null);
+            result[2].should.have.property('error', null);
         });
     });
 

--- a/test/04.group_admin.js
+++ b/test/04.group_admin.js
@@ -21,7 +21,8 @@ describe('GroupAdmin', function () {
             consumer.init({
                 strategy: 'TestStrategy',
                 subscriptions: ['kafka-test-topic'],
-                metadata: 'consumer-metadata'
+                metadata: 'consumer-metadata',
+                handler: function () {}
             })
         ]);
     });

--- a/test/05.other.js
+++ b/test/05.other.js
@@ -9,16 +9,13 @@ describe('requiredAcks: 0', function () {
     var producer = new Kafka.Producer({ requiredAcks: 0, clientId: 'producer' });
     var consumer = new Kafka.SimpleConsumer({ idleTimeout: 100, clientId: 'simple-consumer' });
 
-    var dataListenerSpy = sinon.spy(function () {});
+    var dataHanlderSpy = sinon.spy(function () {});
 
     before(function () {
         return Promise.all([
             producer.init(),
             consumer.init()
-        ])
-        .then(function () {
-            consumer.on('data', dataListenerSpy);
-        });
+        ]);
     });
 
     after(function () {
@@ -29,7 +26,7 @@ describe('requiredAcks: 0', function () {
     });
 
     it('should send/receive messages', function () {
-        return consumer.subscribe('kafka-test-topic', 0).then(function () {
+        return consumer.subscribe('kafka-test-topic', 0, dataHanlderSpy).then(function () {
             return producer.send({
                 topic: 'kafka-test-topic',
                 partition: 0,
@@ -39,15 +36,15 @@ describe('requiredAcks: 0', function () {
         .delay(100)
         .then(function () {
             /* jshint expr: true */
-            dataListenerSpy.should.have.been.called; // eslint-disable-line
-            dataListenerSpy.lastCall.args[0].should.be.an('array').and.have.length(1);
-            dataListenerSpy.lastCall.args[1].should.be.a('string', 'kafka-test-topic');
-            dataListenerSpy.lastCall.args[2].should.be.a('number', 0);
+            dataHanlderSpy.should.have.been.called; // eslint-disable-line
+            dataHanlderSpy.lastCall.args[0].should.be.an('array').and.have.length(1);
+            dataHanlderSpy.lastCall.args[1].should.be.a('string', 'kafka-test-topic');
+            dataHanlderSpy.lastCall.args[2].should.be.a('number', 0);
 
-            dataListenerSpy.lastCall.args[0][0].should.be.an('object');
-            dataListenerSpy.lastCall.args[0][0].should.have.property('message').that.is.an('object');
-            dataListenerSpy.lastCall.args[0][0].message.should.have.property('value');
-            dataListenerSpy.lastCall.args[0][0].message.value.toString('utf8').should.be.eql('p00');
+            dataHanlderSpy.lastCall.args[0][0].should.be.an('object');
+            dataHanlderSpy.lastCall.args[0][0].should.have.property('message').that.is.an('object');
+            dataHanlderSpy.lastCall.args[0][0].message.should.have.property('value');
+            dataHanlderSpy.lastCall.args[0][0].message.value.toString('utf8').should.be.eql('p00');
         });
     });
 });

--- a/test/06.strategies.js
+++ b/test/06.strategies.js
@@ -40,7 +40,8 @@ describe('Weighted Round Robin Assignment', function () {
                 metadata: {
                     weight: ind + 1
                 },
-                fn: Kafka.WeightedRoundRobinAssignment
+                fn: Kafka.WeightedRoundRobinAssignment,
+                handler: function () {}
             });
         }).delay(200);
     });
@@ -88,7 +89,8 @@ describe('Consistent Assignment', function () {
                     id: 'id' + ind,
                     weight: 10
                 },
-                fn: Kafka.ConsistentAssignment
+                fn: Kafka.ConsistentAssignment,
+                handler: function () {}
             });
         }).delay(200);
     });


### PR DESCRIPTION
So this is basically the first attempt to get rid of data events and start using promised data handler.

Using SimpleConsumer:

```javascript
function handler(messageSet, topic, partition) {
    messageSet.forEach(function (m) {
        console.log(topic, partition, m.message.value.toString('utf8'));
    });
    return Promise.delay(1000);
}

return consumer.init()
.then(function () {
    return Promise.all([
        consumer.subscribe('kafka-test-topic', 0, handler),
        consumer.subscribe('kafka-test-topic', 1, handler)
    ]);
})
```

So each topic/partition can have its own handler, or a shared one. 

If handler returns a Promise then this Promise will be awaited (for being resolved or rejected) and no fetch requests will be sent __for this particular topic/partition pair__. Fetch requests for other subscribed topic/partitions will be still be sent and processed (and awaited while their handler settles). 

GroupConsumer:

```javascript
var strategies = [{
    strategy: 'TestStrategy1',
    subscriptions: ['kaka-test-topic'],
    handler: handler
}];

consumer.init(strategies[0]);
```

Here, the handler is specified per Strategy so that consumer can use different handlers if it for example is performing a rolling upgrade to some new strategy. 

handler here is called for each assigned topic/partition and the same behaviour is applied - new message for particular topic/partition won't be fetched until the handler which is currently processing this pair returns (with a settled promised).

There is a question what no-kafka should do if the handler fails (settles with rejected promise). I think it should advance fetch offset and keep calling the handler for next messages. It is up to the user to wrap all necessary code in the handler and handle all the rejections, possibly retrying to process messages.

@estliberitas @ismriv Thoughts?
 