### PR TITLE
Batching (grouping) of Producer requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,44 @@ return producer.send(messages, {
 });
 ```
 
+Accumulate messages into single batch until their total size is >= 1024 bytes or 100ms timeout expires (overwrite Producer constructor options):
+
+```javascript
+producer.send(messages, {
+  batch: {
+    size: 1024,
+    maxWait: 100
+  }
+});
+producer.send(messages, {
+  batch: {
+    size: 1024,
+    maxWait: 100
+  }
+});
+```
+
+Please note, that if you pass different options to the `send()` method then these messages will be grouped into separate batches:
+
+```javascript
+// will be sent in batch 1
+producer.send(messages, {
+  batch: {
+    size: 1024,
+    maxWait: 100
+  },
+  codec: Kafka.COMPRESSION_GZIP
+});
+// will be sent in batch 2
+producer.send(messages, {
+  batch: {
+    size: 1024,
+    maxWait: 100
+  },
+  codec: Kafka.COMPRESSION_SNAPPY
+});
+```
+
 Send message with Snappy compression:
 
 ```javascript
@@ -68,6 +106,9 @@ return producer.send(messages, { codec: Kafka.COMPRESSION_SNAPPY });
   * `attempts` - number of total attempts to send the message, defaults to 3
   * `delay` - delay in ms between retries, defaults to 1000
 * `codec` - compression codec, one of Kafka.COMPRESSION_NONE, Kafka.COMPRESSION_SNAPPY, Kafka.COMPRESSION_GZIP
+* `batch` - control batching (grouping) of requests
+  * `size` - group messages together into single batch until their total size exceeds this value, defaults to 16384 bytes. Set to 0 to disable batching.
+  * `maxWait` - send grouped messages after this amount of milliseconds expire even if their total size doesn't exceed `batch.size` yet, defaults to 10ms. Set to 0 to disable batching.
 
 ## SimpleConsumer
 

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -14,6 +14,10 @@ function Producer(options) {
             attempts: 3,
             delay: 1000
         },
+        batch: {
+            size: 16384,
+            maxWait: 10
+        },
         codec: Kafka.COMPRESSION_NONE
     });
 
@@ -23,6 +27,8 @@ function Producer(options) {
 
     this.partitioner = options.partitioner;
     this.client = new Client(this.options);
+
+    this.queue = {};
 }
 
 module.exports = Producer;
@@ -66,30 +72,18 @@ Producer.prototype._prepareProduceRequest = function (data) {
     }, { concurrency: 10 }).return(data);
 };
 
-/**
- * Send message or messages to Kafka
- *
- * @param  {Object|Array} data [{ topic, partition, message: {key, value, attributes} }]
- * @param  {Object} options { codec, retries: { attempts, delay } }
- * @return {Promise}
- */
-Producer.prototype.send = function (data, options) {
-    var self = this, result = [];
+Producer.prototype._send = function (hash) {
+    var self = this, task = self.queue[hash], data, result = [];
 
-    if (!Array.isArray(data)) {
-        data = [data];
-    }
+    delete self.queue[hash];
 
-    options = _.merge({}, {
-        codec: self.options.codec,
-        retries: self.options.retries
-    }, options || {});
+    data = Array.prototype.concat.apply([], task.data);
 
-    function _try(_data, attempt) {
+    (function _try(_data, attempt) {
         attempt = attempt || 1;
 
         return self._prepareProduceRequest(_data).then(function (requests) {
-            return self.client.produceRequest(requests, options.codec).then(function (response) {
+            return self.client.produceRequest(requests, task.options.codec).then(function (response) {
                 var toRetry = [];
                 if (_.isEmpty(response)) { // if requiredAcks = 0
                     return response;
@@ -98,7 +92,7 @@ Producer.prototype.send = function (data, options) {
                     if (p.error) {
                         if ((/UnknownTopicOrPartition|NotLeaderForPartition|LeaderNotAvailable/.test(p.error.code)
                                 || p.error instanceof errors.NoKafkaConnectionError)
-                            && attempt < options.retries.attempts) {
+                            && attempt < task.options.retries.attempts) {
                             // self.client.debug('Received', p.error, 'for', p.topic + ':' + p.partition);
                             toRetry = toRetry.concat(_.filter(_data, { topic: p.topic, partition: p.partition }));
                         } else {
@@ -110,18 +104,82 @@ Producer.prototype.send = function (data, options) {
                 })
                 .then(function () {
                     if (toRetry.length) {
-                        return Promise.delay(options.retries.delay).then(function () {
+                        return Promise.delay(task.options.retries.delay).then(function () {
                             return self.client.updateMetadata().then(function () {
                                 return _try(toRetry, ++attempt);
                             });
                         });
                     }
-                }).return(result);
+                });
             });
         });
+    }(data))
+    .then(function () {
+        task.resolve(result);
+    })
+    .catch(function (err) {
+        task.reject(err);
+    });
+};
+
+/**
+ * Send message or messages to Kafka
+ *
+ * @param  {Object|Array} data [{ topic, partition, message: {key, value, attributes} }]
+ * @param  {Object} options { codec, retries: { attempts, delay }, batch: { size } }
+ * @return {Promise}
+ */
+Producer.prototype.send = function (data, options) {
+    var self = this, hash, promise, task;
+
+    if (!Array.isArray(data)) {
+        data = [data];
     }
 
-    return _try(data);
+    options = _.merge({}, {
+        codec: self.options.codec,
+        retries: self.options.retries,
+        batch: self.options.batch
+    }, options || {});
+
+    hash = [
+        options.codec,
+        options.retries.attempts,
+        options.retries.delay,
+        options.batch.size,
+        options.batch.maxWait,
+    ].join('.');
+
+    if (self.queue[hash] === undefined) {
+        promise = new Promise(function (resolve, reject) {
+            self.queue[hash] = {
+                timeout: null,
+                resolve: resolve,
+                reject: reject,
+                options: options,
+                data: [],
+                dataSize: 0
+            };
+        });
+        self.queue[hash].promise = promise;
+    }
+
+    task = self.queue[hash];
+    task.data.push(data);
+    task.dataSize += _.sumBy(data, _.partialRight(_.get, 'message.value.length', 0));
+
+    if (task.dataSize >= options.batch.size || options.batch.maxWait === 0) {
+        if (task.timeout !== null) {
+            clearTimeout(task.timeout);
+        }
+        self._send(hash);
+    } else if (task.timeout === null) {
+        task.timeout = setTimeout(function () {
+            self._send(hash);
+        }, options.batch.maxWait);
+    }
+
+    return task.promise;
 };
 
 /**


### PR DESCRIPTION
Adds grouping of producer requests either by `batch.size` options or `batch.maxWait`, whichever happens first. 

Resolves #16 