### PR TITLE
DefaultPartitioner implementation

### DIFF
--- a/lib/default_partitioner.js
+++ b/lib/default_partitioner.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var murmur2 = require('murmur-hash-js').murmur2;
+
+var SEED = 0x9747b28c;
+
+function toPositive(n) {
+    return n & 0x7fffffff;
+}
+
+function getRandomInt() {
+    return Math.floor(Math.random() * 0xFFFFFFFF - 0x80000000);
+}
+
+// https://github.com/apache/kafka/blob/0.9.0/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java#L36
+function DefaultPartitioner(seed) {
+    this.counter = typeof seed === 'number' ? seed | 0 : getRandomInt();
+}
+
+DefaultPartitioner.prototype.getAndIncrement = function getAndIncrement() {
+    var nextValue = this.counter;
+
+    this.counter = this.counter + 1 | 0;
+
+    return nextValue;
+};
+
+DefaultPartitioner.prototype.hashKey = function hashKey(key) {
+    // Must convert to buffer before hashing due to issue with unicode
+    // https://github.com/b3nj4m/murmurhash-js/pull/1
+    var buf = Buffer.isBuffer(key) ? key : Buffer(key);
+
+    return murmur2(buf, SEED);
+};
+
+DefaultPartitioner.prototype.getKey = function getKey(message) {
+    return message.key;
+};
+
+DefaultPartitioner.prototype.partition = function partition(topicName, partitions, message) {
+    var key = this.getKey(message);
+
+    // Round-robin partitioner
+    if (key === undefined || key === null) {
+        return toPositive(this.getAndIncrement()) % partitions.length;
+    }
+
+    // Hash partitioner
+    return toPositive(this.hashKey(key)) % partitions.length;
+};
+
+module.exports = DefaultPartitioner;

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ module.exports = (function () {
     exports.SimpleConsumer = require('./simple_consumer');
     exports.GroupConsumer = require('./group_consumer');
     exports.GroupAdmin = require('./group_admin');
+    exports.DefaultPartitioner = require('./default_partitioner');
 
     // offset request time constants
     exports.EARLIEST_OFFSET = -2;

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -1,15 +1,17 @@
 'use strict';
 
-var Promise = require('./bluebird-configured');
-var _       = require('lodash');
-var Client  = require('./client');
-var Kafka   = require('./index');
-var errors  = require('./errors');
+var Promise            = require('./bluebird-configured');
+var _                  = require('lodash');
+var Client             = require('./client');
+var Kafka              = require('./index');
+var errors             = require('./errors');
+var DefaultPartitioner = require('./default_partitioner');
 
 function Producer(options) {
     this.options = _.defaultsDeep(options || {}, {
         requiredAcks: 1,
         timeout: 100,
+        partitioner: new DefaultPartitioner(),
         retries: {
             attempts: 3,
             delay: 1000
@@ -21,12 +23,10 @@ function Producer(options) {
         codec: Kafka.COMPRESSION_NONE
     });
 
-    if (this.options.hasOwnProperty('partitioner') && typeof this.options.partitioner !== 'function') {
-        throw new Error('Partitioner must be a function');
-    }
-
-    if (typeof this.options.partitioner === 'function') {
-        this.partitioner = Promise.method(this.options.partitioner);
+    if (this.options.partitioner instanceof DefaultPartitioner) {
+        this.partitioner = this.options.partitioner;
+    } else {
+        throw new Error('Partitioner must inherit from DefaultPartitioner');
     }
 
     this.client = new Client(this.options);
@@ -53,9 +53,9 @@ Producer.prototype._prepareProduceRequest = function (data) {
             if (typeof d.topic !== 'string' || d.topic === '') {
                 throw new Error('Missing or wrong topic field');
             }
-            if (self.partitioner && !d.hasOwnProperty('partition')) {
+            if (!d.hasOwnProperty('partition')) {
                 return self.client.getTopicPartitions(d.topic).then(function (partitions) {
-                    return self.partitioner(d.topic, partitions, d.message);
+                    return self.partitioner.partition(d.topic, partitions, d.message);
                 })
                 .then(function (partition) {
                     d.partition = partition;

--- a/package.json
+++ b/package.json
@@ -12,14 +12,15 @@
     "kafka"
   ],
   "dependencies": {
-    "bluebird": "^3.3.3",
-    "lodash": "^4.5.0",
     "bin-protocol": "^2.0.7",
+    "bluebird": "^3.3.3",
     "buffer-crc32": "~=0.2.5",
-    "nice-simple-logger": "^1.0.1",
     "hashring": "~=3.2.0",
-    "wrr-pool": "^1.0.3",
-    "snappy": "^4.1.2"
+    "lodash": "^4.5.0",
+    "murmur-hash-js": "^1.0.0",
+    "nice-simple-logger": "^1.0.1",
+    "snappy": "^4.1.2",
+    "wrr-pool": "^1.0.3"
   },
   "devDependencies": {
     "mocha": "^2.4.5",

--- a/test/09.default_partitioner.js
+++ b/test/09.default_partitioner.js
@@ -1,0 +1,77 @@
+'use strict';
+
+/* global describe, it */
+
+var util = require('util');
+var _    = require('lodash');
+
+var DefaultPartitioner = require('../lib/default_partitioner');
+
+// Ran against Java DefaultPartitioner with 12 partitions
+// https://gist.github.com/kjvalencik/74ff9c7451878d150819
+// https://github.com/apache/kafka/blob/0.9.0/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java
+var numPartitions = 120;
+var expectedPartitions = {
+    '\u263a tlw61or'         : 101,
+    '\u263a ww50w20ggb9'     : 26,
+    '\u263a tf706z9i2v86w29' : 40,
+    '\u263a pgb9'            : 1,
+    '\u263a b9'              : 8
+};
+
+describe('Default Partitioner', function () {
+    it('should be able to seed round robin partitioner', function () {
+        var partitioner = new DefaultPartitioner(0);
+
+        partitioner.partition('topic', new Array(10), {}).should.equal(0);
+    });
+
+    it('should increment after each call to round robin partitioner', function () {
+        var partitioner = new DefaultPartitioner(0);
+
+        partitioner.partition('topic', new Array(10), {}).should.equal(0);
+        partitioner.partition('topic', new Array(10), {}).should.equal(1);
+        partitioner.partition('topic', new Array(10), {}).should.equal(2);
+    });
+
+    it('should choose random seed if one is not provided', function () {
+        var partitioner = new DefaultPartitioner();
+        var seed = partitioner.partition('topic', new Array(10), {});
+
+        partitioner.partition('topic', new Array(10), {}).should.equal((seed + 1) % 10);
+    });
+
+    it('should partition correctly with murmur2', function () {
+        var partitioner = new DefaultPartitioner();
+
+        _.each(expectedPartitions, function (partition, key) {
+            partitioner.partition('topic', new Array(numPartitions), {
+                key : key
+            }).should.equal(partition);
+
+            partitioner.partition('topic', new Array(numPartitions), {
+                key : Buffer(key)
+            }).should.equal(partition);
+        });
+    });
+
+    it('should be able to inherit from DefaultPartitioner', function () {
+        var partitioner;
+
+        function MyPartitioner() {
+            DefaultPartitioner.apply(this, arguments);
+        }
+
+        util.inherits(MyPartitioner, DefaultPartitioner);
+
+        MyPartitioner.prototype.getKey = function getKey(message) {
+            return message.key.split('-')[0];
+        };
+
+        partitioner = new MyPartitioner();
+
+        partitioner.partition('topic', new Array(12), {
+            key : 'msg 1-Something else'
+        }).should.equal(6);
+    });
+});


### PR DESCRIPTION
This commit adds in `DefaultPartitioner` logic. It should produce the same partitions as the Java partitioner and the Python partitioner.

1. If a key is not provided and a partition is not provided, choose a partition by round robin.
2. If a key is provided and neither a partition or a partitioner is provided, hash the key with `murmur2` and modulo the number of partitions.

This commit might seem a bit more complex than it needs to be. But, I wanted to produce the same partitions as the Java implementation for easier migration. Also, I wanted to make `DefaultPartitioner` a class that could be easily extended to provide a partitioner that uses a custom key but `murmur2` for hashing.

Thanks, for the great library! Let me know if there are any changes you would like me to make or if you don't believe that this belongs in core.

Cheers!