### PR TITLE
Receive connection information from the environment, if available

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -7,13 +7,14 @@ var errors      = require('./errors');
 var _           = require('lodash');
 var Logger      = require('nice-simple-logger');
 var compression = require('./protocol/misc/compression');
+var url         = require('url');
 
 function Client(options) {
     var self = this, logger;
 
     self.options = _.defaultsDeep(options || {}, {
         clientId: 'no-kafka-client',
-        connectionString: '127.0.0.1:9092',
+        connectionString: process.env.KAFKA_URL || 'kafka://127.0.0.1:9092',
         asyncCompression: false,
         logger: {
             logLevel: 5,
@@ -69,16 +70,13 @@ Client.prototype.init = function () {
     var self = this;
 
     self.initialBrokers = self.options.connectionString.split(',').map(function (hostStr) {
-        var h = hostStr.trim().split(':');
+        var parsed = url.parse(hostStr);
+        var config = {
+            host: parsed.hostname,
+            port: parsed.port
+        };
 
-        if (h.length < 2) {
-            return undefined;
-        }
-
-        return new Connection({
-            host: h[0],
-            port: parseInt(h[1])
-        });
+        return config.host && config.port ? new Connection(config) : undefined;
     });
 
     self.initialBrokers = _.compact(self.initialBrokers);

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
     "snappy": "^5.0.0"
   },
   "devDependencies": {
-    "mocha": "^2.4.5",
     "chai": "^3.5.0",
-    "sinon-chai": "^2.8.0",
     "chai-as-promised": "^5.2.0",
     "eslint": "^2.2.0",
     "eslint-config-magictoolbox": "^0.0.2",
-    "istanbul": "^0.4.2"
+    "istanbul": "^0.4.2",
+    "mocha": "^2.4.5",
+    "sinon": "^1.4.0",
+    "sinon-chai": "^2.8.0"
   },
   "bugs": {
     "url": "https://github.com/oleksiyk/kafka/issues"


### PR DESCRIPTION
Currently, no-kafka falls back to localhost if no explicit `connectionString` is provided. This PR first attempts to pull `connectionString` from the environment (`KAFKA_URL`), then falls back to localhost if the environment is empty.

The motivation is to make the library and its tests more portable (I'm doing some testing with this 0.9 client on our upcoming Kafka service at Heroku). This PR allows no-kafka to parse url strings in a similar way to node's redis, postgres, and mongodb clients.

I extended `Client` to avoid changing the existing API. An alternative way to accomplish the same thing is to expose a method on no-kafka like `connectionStringFromUrl(url)`. Then, tests could be updated from:

```js
var producer = new Kafka.Producer({
    requiredAcks: 1,
    clientId: 'producer'
});
```

to:

```js
var producer = new Kafka.Producer({
    requiredAcks: 1,
    clientId: 'producer',
    connectionString: Kafka.connectionStringFromUrl(process.env.KAFKA_URL)
});
```

If you'd prefer that API change instead, let me know and I'll submit a separate PR.

Cheers, and thanks for creating a 0.9-compatible node client!