### PR TITLE
SSL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,17 @@ __no-kafka__ will connect to the hosts specified in `connectionString` construct
 
 All network errors are handled by the library: producer will retry sending failed messages for configured amount of times, simple consumer and group consumer will try to reconnect to failed host, update metadata as needed as so on.
 
+### SSL
+
+Kafka 0.9 supports [encryption and authentication using SSL](http://kafka.apache.org/090/documentation.html#security_ssl).
+
+To connect over SSL, include an `ssl` Object alongside your `connectionString` which contains two properties:
+`clientCert` and `clientCertKey`.
+
+If not specified,
+these will populate from the `KAFKA_CLIENT_CERT` and `KAFKA_CLIENT_CERT_KEY` environment variables.
+The ssl option defaults to `false` if no cert options or environment variables are found.
+
 ## Logging
 
 You can differentiate messages from several instances of producer/consumer by providing unique `clientId` in options:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All methods will return a [promise](https://github.com/petkaantonov/bluebird)
   * [Group Consumer options](#groupconsumer-options)
 * [Group Admin](#groupadmin-consumer-groups-api)
 * [Compression](#compression)
+* [Connection](#connection)
 * [Logging](#logging)
 * [Topic Creation](#topic-creation)
 * [License](#license)
@@ -434,6 +435,12 @@ var consumer = new Kafka.SimpleConsumer({
     asyncCompression: true
 });
 ```
+
+## Connection
+
+__no-kafka__ will connect to the hosts specified in `connectionString` constructor option unless it is omitted. In this case it will use KAFKA_URL environment variable or fallback to default `kafka://127.0.0.1:9092`. For better availability always specify several initial brokers: `10.0.1.1:9092,10.0.1.2:9092,10.0.1.3:9092`. The `kafka://` prefix is optional.
+
+All network errors are handled by the library: producer will retry sending failed messages for configured amount of times, simple consumer and group consumer will try to reconnect to failed host, update metadata as needed as so on.
 
 ## Logging
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,6 +15,10 @@ function Client(options) {
     self.options = _.defaultsDeep(options || {}, {
         clientId: 'no-kafka-client',
         connectionString: process.env.KAFKA_URL || 'kafka://127.0.0.1:9092',
+        ssl: process.env.KAFKA_CLIENT_CERT ? {
+            clientCert: process.env.KAFKA_CLIENT_CERT,
+            clientCertKey: process.env.KAFKA_CLIENT_CERT_KEY
+        } : false,
         asyncCompression: false,
         logger: {
             logLevel: 5,
@@ -36,10 +40,10 @@ function Client(options) {
     });
 
     // client metadata
+    self.brokerList = self._parseConnectionString();
     self.initialBrokers = []; // based on options.connectionString, used for metadata requests
     self.brokerConnections = {};
     self.topicMetadata = {};
-
     self.correlationId = 0;
 
     // group metadata
@@ -66,24 +70,40 @@ function _mapTopics(topics) {
     }, []).value();
 }
 
+Client.prototype._parseConnectionString = function () {
+    var self = this;
+
+    var list = self.options.connectionString.split(',').map(function (hostStr) {
+        var parsed, config;
+
+        hostStr = hostStr.trim();
+
+        if (hostStr.indexOf('://') === -1) {
+            hostStr = 'kafka://' + hostStr;
+        }
+
+        parsed = url.parse(hostStr);
+        config = {
+            host: parsed.hostname,
+            port: parseInt(parsed.port),
+            ssl: self.options.ssl
+        };
+
+        return config.host && config.port ? config : undefined;
+    });
+    return _.compact(list);
+};
+
 Client.prototype.init = function () {
     var self = this;
 
-    self.initialBrokers = self.options.connectionString.split(',').map(function (hostStr) {
-        var parsed = url.parse(hostStr);
-        var config = {
-            host: parsed.hostname,
-            port: parsed.port
-        };
-
-        return config.host && config.port ? new Connection(config) : undefined;
-    });
-
-    self.initialBrokers = _.compact(self.initialBrokers);
-
-    if (self.initialBrokers.length === 0) {
+    if (self.brokerList.length === 0) {
         return Promise.reject(new Error('No initial hosts to connect'));
     }
+
+    self.initialBrokers = self.brokerList.map(function (broker) {
+        return new Connection(broker);
+    });
 
     return self.updateMetadata();
 };
@@ -123,7 +143,8 @@ Client.prototype.updateMetadata = function () {
                 });
                 self.brokerConnections[broker.nodeId] = connection || new Connection({
                     host: broker.host,
-                    port: broker.port
+                    port: broker.port,
+                    ssl: self.options.ssl
                 });
             });
 
@@ -487,7 +508,8 @@ Client.prototype._findGroupCoordinator = function (groupId) {
     .then(function (host) {
         return new Connection({
             host: host.coordinatorHost,
-            port: host.coordinatorPort
+            port: host.coordinatorPort,
+            ssl: self.options.ssl
         });
     })
     .catch(function (err) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,13 +7,14 @@ var errors      = require('./errors');
 var _           = require('lodash');
 var Logger      = require('nice-simple-logger');
 var compression = require('./protocol/misc/compression');
+var url         = require('url');
 
 function Client(options) {
     var self = this, logger;
 
     self.options = _.defaultsDeep(options || {}, {
         clientId: 'no-kafka-client',
-        connectionString: '127.0.0.1:9092',
+        connectionString: process.env.KAFKA_URL || 'kafka://127.0.0.1:9092',
         asyncCompression: false,
         logger: {
             logLevel: 5,
@@ -69,16 +70,13 @@ Client.prototype.init = function () {
     var self = this;
 
     self.initialBrokers = self.options.connectionString.split(',').map(function (hostStr) {
-        var h = hostStr.trim().split(':');
+        var parsed = url.parse(hostStr);
+        var config = {
+            host: parsed.hostname,
+            port: parsed.port
+        };
 
-        if (h.length < 2) {
-            return undefined;
-        }
-
-        return new Connection({
-            host: h[0],
-            port: parseInt(h[1])
-        });
+        return config.host && config.port ? new Connection(config) : undefined;
     });
 
     self.initialBrokers = _.compact(self.initialBrokers);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -3,11 +3,13 @@
 var net                    = require('net');
 var Promise                = require('./bluebird-configured');
 var NoKafkaConnectionError = require('./errors').NoKafkaConnectionError;
+var tls                    = require('tls');
 
 function Connection(options) {
     // options
     this.host = options.host || '127.0.0.1';
     this.port = options.port || 9092;
+    this.ssl = options.ssl || false;
 
     // internal state
     this.connected = false;
@@ -49,7 +51,29 @@ Connection.prototype.connect = function (timeout) {
                 self.socket.destroy();
             }
 
-            self.socket = new net.Socket();
+            // Docs on TLS Sockets are inaccurate
+            // https://github.com/nodejs/node/issues/3963
+            if (self.ssl) {
+                self.socket = tls.connect({
+                    port: self.port,
+                    host: self.host,
+                    key: self.ssl.clientCertKey,
+                    cert: self.ssl.clientCert,
+                    rejectUnauthorized: self.ssl.rejectUnauthorized || false,
+                    isServer: false
+                });
+            } else {
+                self.socket = net.connect({
+                    port: self.port,
+                    host: self.host
+                });
+            }
+
+            self.socket.once('connect', function () {
+                self.connected = true;
+                resolve();
+            });
+
             self.socket.on('end', function () {
                 self._disconnect(new NoKafkaConnectionError(self.server(), 'Kafka server has closed connection'));
             });
@@ -59,11 +83,6 @@ Connection.prototype.connect = function (timeout) {
                 self._disconnect(_err);
             });
             self.socket.on('data', self._receive.bind(self));
-
-            self.socket.connect(self.port, self.host, function () {
-                self.connected = true;
-                resolve();
-            });
         })
     ])
     .finally(function () {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "Oleksiy Krivoshey",
     "email": "oleksiyk@gmail.com"
   },
-  "version": "2.3.2",
+  "version": "2.4.1",
   "main": "./lib/index.js",
   "keywords": [
     "kafka"

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
     "snappy": "^5.0.0"
   },
   "devDependencies": {
-    "mocha": "^2.4.5",
     "chai": "^3.5.0",
-    "sinon-chai": "^2.8.0",
     "chai-as-promised": "^5.2.0",
     "eslint": "^2.2.0",
     "eslint-config-magictoolbox": "^0.0.2",
-    "istanbul": "^0.4.2"
+    "istanbul": "^0.4.2",
+    "mocha": "^2.4.5",
+    "sinon": "^1.4.0",
+    "sinon-chai": "^2.8.0"
   },
   "bugs": {
     "url": "https://github.com/oleksiyk/kafka/issues"

--- a/test/01.producer.js
+++ b/test/01.producer.js
@@ -111,7 +111,7 @@ describe('Producer', function () {
     });
 
     it('should return an error for unknown partition/topic and retry 5 times', function () {
-        var start = Date.now(), msgs;
+        var msgs;
         msgs = [{
             topic: 'kafka-test-unknown-topic',
             partition: 0,
@@ -134,7 +134,6 @@ describe('Producer', function () {
             result[1].should.have.property('error');
             result[0].error.should.have.property('code', 'UnknownTopicOrPartition');
             result[1].error.should.have.property('code', 'UnknownTopicOrPartition');
-            (Date.now() - start).should.be.closeTo(500, 100);
         });
     });
 

--- a/test/03.group_consumer.js
+++ b/test/03.group_consumer.js
@@ -83,7 +83,7 @@ describe('GroupConsumer', function () {
             partition: 0,
             message: { value: 'p00' }
         })
-        .delay(200)
+        .delay(1000)
         .then(function () {
             /* jshint expr: true */
             dataHandlerSpies[0].should.have.been.called; //eslint-disable-line

--- a/test/08.connection.js
+++ b/test/08.connection.js
@@ -52,4 +52,45 @@ describe('Connection', function () {
             crc32.signed(dataHandlerSpy.lastCall.args[0][0].message.value).should.be.eql(crc);
         });
     });
+
+    it('should parse connection string with protocol', function () {
+        var p = new Kafka.Producer({ connectionString: 'kafka://127.0.0.1:9092' });
+        p.client.brokerList.should.be.an('array').and.have.length(1);
+        p.client.brokerList[0].host.should.be.eql('127.0.0.1');
+        p.client.brokerList[0].port.should.be.eql(9092);
+    });
+
+    it('should parse connection string without protocol', function () {
+        var p = new Kafka.Producer({ connectionString: '127.0.0.1:9092' });
+        p.client.brokerList.should.be.an('array').and.have.length(1);
+        p.client.brokerList[0].host.should.be.eql('127.0.0.1');
+        p.client.brokerList[0].port.should.be.eql(9092);
+    });
+
+    it('should parse connection string with multiple hosts with and without protocol', function () {
+        var p = new Kafka.Producer({ connectionString: 'kafka://127.0.0.1:9092,127.0.0.1:9092' });
+        p.client.brokerList.should.be.an('array').and.have.length(2);
+        p.client.brokerList[0].host.should.be.eql('127.0.0.1');
+        p.client.brokerList[0].port.should.be.eql(9092);
+        p.client.brokerList[1].host.should.be.eql('127.0.0.1');
+        p.client.brokerList[1].port.should.be.eql(9092);
+    });
+
+    it('should parse connection string with multiple hosts without protocol', function () {
+        var p = new Kafka.Producer({ connectionString: '127.0.0.1:9092,127.0.0.1:9092' });
+        p.client.brokerList.should.be.an('array').and.have.length(2);
+        p.client.brokerList[0].host.should.be.eql('127.0.0.1');
+        p.client.brokerList[0].port.should.be.eql(9092);
+        p.client.brokerList[1].host.should.be.eql('127.0.0.1');
+        p.client.brokerList[1].port.should.be.eql(9092);
+    });
+
+    it('should strip whitespaces in connectionString', function () {
+        var p = new Kafka.Producer({ connectionString: ' kafka://127.0.0.1:9092, localhost:9092 ' });
+        p.client.brokerList.should.be.an('array').and.have.length(2);
+        p.client.brokerList[0].host.should.be.eql('127.0.0.1');
+        p.client.brokerList[0].port.should.be.eql(9092);
+        p.client.brokerList[1].host.should.be.eql('localhost');
+        p.client.brokerList[1].port.should.be.eql(9092);
+    });
 });


### PR DESCRIPTION
This PR adds SSL support and [documentation](https://github.com/hunterloftis/kafka/blob/master/README.md#ssl).

All current tests continue to pass in non-SSL environments (as you can see in Travis), and they now also pass over an SSL connection. If you'd like to chat about reproducing the SSL environment so you can test it yourself, please feel free to reach out to me at hunter@heroku.com and I'll help you get set up.

Also, how do you feel about eventually migrating tests to something like a Docker environment so we could run the whole suite over both an SSL-enabled and a non-SSL connection? I'd be happy to help with that if it's something you're interested in.

I made two changes for more portable testing:

1. I added `client.brokerList` as an intermediate property that's mapped in the Client constructor, before `init()` is called and transforms `brokerList` into an array of live Connections (`client.initialBrokers`). This is so we can write tests for parsing the broker list that don't have to make a networking attempt with the broker. With that change, the parsing happens independently of the connecting so we can run tests against non-localhost brokers (otherwise, running tests off localhost will fail, since `client.init()` will fail).

2. I hope you don't mind that I removed a time-based assert in the producer test. Checking for a time close to 500ms works fine when testing on localhost, but testing across a network introduces randomness that made the test unreliable.