### PR TITLE
Compression promises

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -238,20 +238,7 @@ function _fakeTopicsErrorResponse(topics, error) {
 }
 
 Client.prototype.produceRequest = function (requests, codec) {
-    var self = this, compressionPromises = [];
-
-    function asyncPartitionMessageSet(pv, pk) {
-        var _r = {
-            partition: parseInt(pk),
-            messageSet: []
-        };
-        compressionPromises.push(self._compressMessageSet(_.map(pv, function (mv) {
-            return { offset: 0, message: mv.message };
-        }), codec).then(function (messageSet) {
-            _r.messageSet = messageSet;
-        }));
-        return _r;
-    }
+    var self = this, leaderPromises;
 
     return self._waitMetadata().then(function () {
         requests = _(requests).groupBy('leader').mapValues(function (v) {
@@ -260,14 +247,32 @@ Client.prototype.produceRequest = function (requests, codec) {
                 .map(function (p, t) {
                     return {
                         topicName: t,
-                        partitions: _(p).groupBy('partition').map(asyncPartitionMessageSet).value()
+                        partitions: _.groupBy(p, 'partition'),
                     };
                 })
                 .value();
         }).value();
 
-        return Promise.all(compressionPromises).then(function () {
-            return Promise.all(_.map(requests, function (topics, leader) {
+        function processPartition(reqs, partition) {
+            return self._compressMessageSet(_.map(reqs, function (req) {
+                return { offset: 0, message: req.message };
+            }), codec)
+            .then(function (messageSet) {
+                return { partition: parseInt(partition), messageSet: messageSet };
+            });
+        }
+
+        leaderPromises = _.mapValues(requests, function processLeader(topics) {
+            return Promise.map(topics, function processTopic(topic) {
+                return Promise.all(_.map(topic.partitions, processPartition))
+                .then(function (partitions) {
+                    return { topicName: topic.topicName, partitions: partitions };
+                });
+            });
+        });
+
+        return Promise.props(leaderPromises).then(function (compressedRequests) {
+            return Promise.all(_.map(compressedRequests, function (topics, leader) {
                 var buffer = self.protocol.write().ProduceRequest({
                     correlationId: self.correlationId++,
                     clientId: self.options.clientId,

--- a/lib/client.js
+++ b/lib/client.js
@@ -253,15 +253,6 @@ Client.prototype.produceRequest = function (requests, codec) {
         return _r;
     }
 
-    function syncPartitionMessageSet(pv, pk) {
-        return {
-            partition: parseInt(pk),
-            messageSet: self._compressMessageSet(_.map(pv, function (mv) {
-                return { offset: 0, message: mv.message };
-            }), codec)
-        };
-    }
-
     return self._waitMetadata().then(function () {
         requests = _(requests).groupBy('leader').mapValues(function (v) {
             return _(v)
@@ -269,7 +260,7 @@ Client.prototype.produceRequest = function (requests, codec) {
                 .map(function (p, t) {
                     return {
                         topicName: t,
-                        partitions: _(p).groupBy('partition').map(self.options.asyncCompression ? asyncPartitionMessageSet : syncPartitionMessageSet).value()
+                        partitions: _(p).groupBy('partition').map(asyncPartitionMessageSet).value()
                     };
                 })
                 .value();
@@ -666,44 +657,38 @@ Client.prototype._decompressMessageSet = function (message) {
 };
 
 Client.prototype._compressMessageSet = function (messageSet, codec) {
-    var self = this, buffer;
+    var self = this, buffer, compress;
 
-    if (codec !== 0) {
-        buffer = self.protocol.write().MessageSet(messageSet).result;
+    if (codec === 0) { return Promise.resolve(messageSet); }
+    buffer = self.protocol.write().MessageSet(messageSet).result;
 
-        if (self.options.asyncCompression) {
-            return compression.compressAsync(buffer, codec).then(function (_buffer) {
-                return [{
-                    offset: 0,
-                    message: {
-                        value: _buffer,
-                        attributes: {
-                            codec: codec
-                        }
-                    }
-                }];
-            })
-            .catch(function (err) {
-                self.warn('Failed to compress messageSet', err);
-                return messageSet;
-            });
-        }
-
-        try {
-            buffer = compression.compress(buffer, codec);
-            return [{
-                offset: 0,
-                message: {
-                    value: buffer,
-                    attributes: {
-                        codec: codec
-                    }
+    if (self.options.asyncCompression) {
+        compress = compression.compressAsync;
+    } else {
+        compress = function (_buffer, c) {
+            return new Promise(function (resolve, reject) {
+                try {
+                    resolve(compression.compress(buffer, c));
+                } catch (e) {
+                    reject(e);
                 }
-            }];
-        } catch (err) {
-            self.warn('Failed to compress messageSet', err);
-        }
+            });
+        };
     }
 
-    return messageSet;
+    return compress(buffer, codec).then(function (_buffer) {
+        return [{
+            offset: 0,
+            message: {
+                value: _buffer,
+                attributes: {
+                    codec: codec
+                }
+            }
+        }];
+    })
+    .catch(function (err) {
+        self.warn('Failed to compress messageSet', err);
+        return messageSet;
+    });
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -334,21 +334,13 @@ Client.prototype.fetchRequest = function (requests) {
                 r.messageSet = [];
                 ms.forEach(function (m) {
                     if (m.message.attributes.codec !== 0) {
-                        if (self.options.asyncCompression) {
-                            compressionPromises.push(self._decompressMessageSet(m.message)
-                                .then(function (messageSet) {
-                                    r.messageSet = r.messageSet.concat(messageSet);
-                                })
-                                .catch(function (err) {
-                                    self.error('Failed to decompress message at', r.topic + ':' + r.partition + '@' + m.offset, err);
-                                }));
-                        } else {
-                            try {
-                                r.messageSet = r.messageSet.concat(self._decompressMessageSet(m.message));
-                            } catch (err) {
+                        compressionPromises.push(self._decompressMessageSet(m.message)
+                            .then(function (messageSet) {
+                                r.messageSet = r.messageSet.concat(messageSet);
+                            })
+                            .catch(function (err) {
                                 self.error('Failed to decompress message at', r.topic + ':' + r.partition + '@' + m.offset, err);
-                            }
-                        }
+                            }));
                     } else {
                         r.messageSet.push(m);
                     }
@@ -356,11 +348,7 @@ Client.prototype.fetchRequest = function (requests) {
                 return r;
             });
 
-            if (self.options.asyncCompression) {
-                return Promise.all(compressionPromises).return(result);
-            }
-
-            return result;
+            return Promise.all(compressionPromises).return(result);
         });
     });
 };
@@ -645,15 +633,25 @@ Client.prototype.describeGroupRequest = function (groupId) {
 };
 
 Client.prototype._decompressMessageSet = function (message) {
-    var self = this, decompressed;
+    var self = this, decompress;
 
     if (self.options.asyncCompression) {
-        return compression.decompressAsync(message.value, message.attributes.codec).then(function (_decompressed) {
-            return self.protocol.read(_decompressed).MessageSet(null, _decompressed.length).result;
-        });
+        decompress = compression.decompressAsync;
+    } else {
+        decompress = function (buffer, codec) {
+            return new Promise(function (resolve, reject) {
+                try {
+                    resolve(compression.decompress(buffer, codec));
+                } catch (e) {
+                    reject(e);
+                }
+            });
+        };
     }
-    decompressed = compression.decompress(message.value, message.attributes.codec);
-    return self.protocol.read(decompressed).MessageSet(null, decompressed.length).result;
+
+    return decompress(message.value, message.attributes.codec).then(function (buffer) {
+        return self.protocol.read(buffer).MessageSet(null, buffer.length).result;
+    });
 };
 
 Client.prototype._compressMessageSet = function (messageSet, codec) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -327,28 +327,20 @@ Client.prototype.fetchRequest = function (requests) {
             });
         }))
         .then(function (topics) {
-            var compressionPromises = [], result;
-
-            result = _mapTopics(topics).map(function (r) {
-                var ms = r.messageSet || [];
-                r.messageSet = [];
-                ms.forEach(function (m) {
-                    if (m.message.attributes.codec !== 0) {
-                        compressionPromises.push(self._decompressMessageSet(m.message)
-                            .then(function (messageSet) {
-                                r.messageSet = r.messageSet.concat(messageSet);
-                            })
-                            .catch(function (err) {
-                                self.error('Failed to decompress message at', r.topic + ':' + r.partition + '@' + m.offset, err);
-                            }));
-                    } else {
-                        r.messageSet.push(m);
+            return Promise.map(_mapTopics(topics), function (r) {
+                return Promise.map(r.messageSet || [], function (m) {
+                    if (m.message.attributes.codec === 0) {
+                        return Promise.resolve(m);
                     }
-                });
-                return r;
-            });
 
-            return Promise.all(compressionPromises).return(result);
+                    return self._decompressMessageSet(m.message).catch(function (err) {
+                        self.error('Failed to decompress message at', r.topic + ':' + r.partition + '@' + m.offset, err);
+                    });
+                })
+                .then(function (newMessageSet) {
+                    return _.assign({}, r, { messageSet: _.flatten(newMessageSet) });
+                });
+            });
         });
     });
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -633,21 +633,8 @@ Client.prototype.describeGroupRequest = function (groupId) {
 };
 
 Client.prototype._decompressMessageSet = function (message) {
-    var self = this, decompress;
-
-    if (self.options.asyncCompression) {
-        decompress = compression.decompressAsync;
-    } else {
-        decompress = function (buffer, codec) {
-            return new Promise(function (resolve, reject) {
-                try {
-                    resolve(compression.decompress(buffer, codec));
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        };
-    }
+    var self = this;
+    var decompress = self.options.asyncCompression ? compression.decompressAsync : compression.decompress;
 
     return decompress(message.value, message.attributes.codec).then(function (buffer) {
         return self.protocol.read(buffer).MessageSet(null, buffer.length).result;
@@ -655,24 +642,11 @@ Client.prototype._decompressMessageSet = function (message) {
 };
 
 Client.prototype._compressMessageSet = function (messageSet, codec) {
-    var self = this, buffer, compress;
+    var self = this, buffer;
+    var compress = self.options.asyncCompression ? compression.compressAsync : compression.compress;
 
     if (codec === 0) { return Promise.resolve(messageSet); }
     buffer = self.protocol.write().MessageSet(messageSet).result;
-
-    if (self.options.asyncCompression) {
-        compress = compression.compressAsync;
-    } else {
-        compress = function (_buffer, c) {
-            return new Promise(function (resolve, reject) {
-                try {
-                    resolve(compression.compress(buffer, c));
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        };
-    }
 
     return compress(buffer, codec).then(function (_buffer) {
         return [{

--- a/lib/protocol/misc/compression.js
+++ b/lib/protocol/misc/compression.js
@@ -58,12 +58,12 @@ Gzip = {
 module.exports = {
     decompress: function (buffer, codec) {
         if (codec === 2) {
-            return Snappy.decompress(buffer);
+            return Promise.resolve(Snappy.decompress(buffer));
         } else if (codec === 1 && typeof zlib.gunzipSync === 'function') {
-            return Gzip.decompress(buffer);
+            return Promise.resolve(Gzip.decompress(buffer));
         }
         /* istanbul ignore next */
-        throw new Error('Unsupported compression codec ' + codec);
+        return Promise.reject(new Error('Unsupported compression codec ' + codec));
     },
     decompressAsync: function (buffer, codec) {
         if (codec === 2) {
@@ -76,11 +76,11 @@ module.exports = {
     },
     compress: function (buffer, codec) {
         if (codec === 2) {
-            return Snappy.compress(buffer);
+            return Promise.resolve(Snappy.compress(buffer));
         } else if (codec === 1 && typeof zlib.gzipSync === 'function') {
-            return Gzip.compress(buffer);
+            return Promise.resolve(Gzip.compress(buffer));
         }
-        throw new Error('Unsupported compression codec ' + codec);
+        return Promise.reject(new Error('Unsupported compression codec ' + codec));
     },
     compressAsync: function (buffer, codec) {
         if (codec === 2) {


### PR DESCRIPTION
There were a number of branches in the `Client` code that were trying to deal with whether or not the compression technique was synchronous or asynchronous. One of the greatest benefits of using `Promise`s, though, is that they can unify the interactions between sync and async code.

I modified the synchronous compression functions to return `Promise`s, just like their asynchronous counterparts. This allowed for a number of upstream simplifications of the `Client` code.

I split the changes up into separate commits to make reviewing easier, but I can squash if it is preferred.