### PR TITLE
Add Producer.send() arguments description. Plus minor fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ producer.send({
     topic: 'kafka-test-topic',
     partition: 0,
     message: {
-        key: 'some-key'
+        key: 'some-key',
         value: 'Hello!'
     }
 });
@@ -148,7 +148,26 @@ producer.send({
 * `batch` - control batching (grouping) of requests
   * `size` - group messages together into single batch until their total size exceeds this value, defaults to 16384 bytes. Set to 0 to disable batching.
   * `maxWait` - send grouped messages after this amount of milliseconds expire even if their total size doesn't exceed `batch.size` yet, defaults to 10ms. Set to 0 to disable batching.
-* `asyncCompression` - boolean, use asynchronouse compression instead of synchronous, defaults to `false`
+* `asyncCompression` - boolean, use asynchronous compression instead of synchronous, defaults to `false`
+
+### Producer.send()
+```js
+send(data: Data | Data[], options: SendOptions) => Promise
+
+interface Data {
+    topic: String,
+    partition: Number,
+    value: String,
+    key?: String
+}
+
+interface SendOptions {
+    codec: Number,
+    retries: {attempts = 3: Number, delay = 1000: Number},
+    batch: {size = 16384: Number, maxWait = 10: Number}
+}
+```
+
 
 ## SimpleConsumer
 

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -26,7 +26,7 @@ function Producer(options) {
     }
 
     if (typeof this.options.partitioner === 'function') {
-        this.partitioner = Promise.method(this.options.partitioner);
+        this.partitioner = this.options.partitioner;
     }
 
     this.client = new Client(this.options);
@@ -150,7 +150,7 @@ Producer.prototype.send = function (data, options) {
         options.retries.attempts,
         options.retries.delay,
         options.batch.size,
-        options.batch.maxWait,
+        options.batch.maxWait
     ].join('.');
 
     if (self.queue[hash] === undefined) {


### PR DESCRIPTION
To make the method description as readable as possible I used the [rtype](https://github.com/ericelliott/rtype) annotation syntax. It's very expressive and simple. I hope that's okay.

Also, I removed the unnecessary `partitioner` promisification. Because in the code it is returned from a promise, so it'll be promisified automatically.
