### PR TITLE
Handle rapid shutdown of new instances

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -48,6 +48,11 @@ Connection.prototype.connect = function (timeout) {
             if (self.socket) {
                 self.socket.destroy();
             }
+            // If we have aborted/stopped during startup, don't progress.
+            if (self._disconnect_called) {
+                reject(new NoKafkaConnectionError(self.server(), 'Connection was aborted before connection was established.'));
+                return;
+            }
 
             self.socket = new net.Socket();
             self.socket.on('end', function () {
@@ -76,6 +81,8 @@ Connection.prototype.connect = function (timeout) {
 // Private disconnect method, this is what the 'end' and 'error'
 // events call directly to make sure internal state is maintained
 Connection.prototype._disconnect = function (err) {
+    this._disconnect_called = true;
+
     if (!this.connected) {
         return;
     }


### PR DESCRIPTION
When shutting down an instance of no-kafka that is in the middle of a connection, the new connection can be established after the close() has run, causing a connection to not be released.

Fixes #76 