### PR TITLE
Improve Close/Early Disconnect Code

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -38,6 +38,8 @@ Connection.prototype.connect = function (timeout) {
         return self.connecting;
     }
 
+    self._close_called = false;
+
     self.connecting = Promise.race([
         new Promise(function (resolve, reject) {
             setTimeout(function () {
@@ -49,7 +51,7 @@ Connection.prototype.connect = function (timeout) {
                 self.socket.destroy();
             }
             // If we have aborted/stopped during startup, don't progress.
-            if (self._disconnect_called) {
+            if (self._close_called) {
                 reject(new NoKafkaConnectionError(self.server(), 'Connection was aborted before connection was established.'));
                 return;
             }
@@ -81,8 +83,6 @@ Connection.prototype.connect = function (timeout) {
 // Private disconnect method, this is what the 'end' and 'error'
 // events call directly to make sure internal state is maintained
 Connection.prototype._disconnect = function (err) {
-    this._disconnect_called = true;
-
     if (!this.connected) {
         return;
     }
@@ -105,6 +105,8 @@ Connection.prototype._growBuffer = function (newLength) {
 
 Connection.prototype.close = function () {
     var err = new NoKafkaConnectionError(this, 'Connection closed');
+    this._close_called = true;
+
     err._kafka_connection_closed = true;
     this._disconnect(err);
 };


### PR DESCRIPTION
My previous contribution for the rapid cycling/shutdown issue appears to have fallen down in the case where a Kafka instance is temporarily down. The code will set the _disconnected flag, but then cause all subsequent reconnect attempts to terminate.

This change does the following:

- Moves the logic from disconnect to close
- Renames the variable to reflect it's new home.
