### PR TITLE
Clear out timeout timer when connection is made

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -30,6 +30,7 @@ Connection.prototype.server = function () {
 
 Connection.prototype.connect = function (timeout) {
     var self = this;
+    self.timerHandle = null;
 
     if (self.connected) {
         return Promise.resolve();
@@ -41,7 +42,7 @@ Connection.prototype.connect = function (timeout) {
 
     self.connecting = Promise.race([
         new Promise(function (resolve, reject) {
-            setTimeout(function () {
+            self.timerHandle = setTimeout(function () {
                 reject(new NoKafkaConnectionError(self.server(), 'Connection timeout'));
             }, timeout || 3000);
         }),
@@ -68,6 +69,7 @@ Connection.prototype.connect = function (timeout) {
             self.socket.on('data', self._receive.bind(self));
 
             self.socket.connect(self.port, self.host, function () {
+                clearTimeout(self.timerHandle);
                 self.connected = true;
                 resolve();
             });


### PR DESCRIPTION
I init() a connection, send() messages and then end() the connection in less than 500ms.  The timer was on the event loop so node would exit after 3+ seconds.  My logic now exits in less than 500ms with this change.