### PR TITLE
Make Snappy Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ return admin.init().then(function(){
 
 ## Compression
 
-__no-kafka__ supports both SNAPPY and Gzip compression.
+__no-kafka__ supports both SNAPPY and Gzip compression. To use SNAPPY you must install the `snappy` NPM module in your project.
 
 Enable compression in Producer:
 

--- a/lib/protocol/misc/compression.js
+++ b/lib/protocol/misc/compression.js
@@ -1,18 +1,18 @@
 'use strict';
 
-function requireSafe(moduleName) {
-  try {
-    require.resolve(moduleName);
-    return require(moduleName);
-  } catch (err) {
-    return undefined;
-  }
-}
-
 var Promise = require('bluebird');
 var snappy  = requireSafe('snappy');
 var zlib    = require('zlib');
 var _ = require('lodash');
+
+function requireSafe(moduleName) {
+    try {
+        require.resolve(moduleName);
+        return require(moduleName);
+    } catch (err) {
+        return undefined;
+    }
+}
 
 var SNAPPY_MAGIC_HEADER = new Buffer([-126, 83, 78, 65, 80, 80, 89, 0]); // '\x82SNAPPY\00'
 /*var SNAPPY_BLOCK_SIZE = 32 * 1024;
@@ -68,7 +68,7 @@ module.exports = {
     decompress: function (buffer, codec) {
         if (codec === 2) {
             if (!snappy) {
-              return Promise.reject(new Error('Snappy is not installed. Please install it to use this codec.'));
+                return Promise.reject(new Error('Snappy is not installed. Please install it to use this codec.'));
             }
             return Promise.resolve(Snappy.decompress(buffer));
         } else if (codec === 1 && typeof zlib.gunzipSync === 'function') {
@@ -92,7 +92,7 @@ module.exports = {
     compress: function (buffer, codec) {
         if (codec === 2) {
             if (!snappy) {
-              return Promise.reject(new Error('Snappy is not installed. Please install it to use this codec.'));
+                return Promise.reject(new Error('Snappy is not installed. Please install it to use this codec.'));
             }
             return Promise.resolve(Snappy.compress(buffer));
         } else if (codec === 1 && typeof zlib.gzipSync === 'function') {
@@ -103,7 +103,7 @@ module.exports = {
     compressAsync: function (buffer, codec) {
         if (codec === 2) {
             if (!snappy) {
-              return Promise.reject(new Error('Snappy is not installe. Please install it to use this codec.'));
+                return Promise.reject(new Error('Snappy is not installe. Please install it to use this codec.'));
             }
             return Snappy.compressAsync(buffer);
         } else if (codec === 1) {

--- a/lib/protocol/misc/compression.js
+++ b/lib/protocol/misc/compression.js
@@ -1,7 +1,16 @@
 'use strict';
 
+function requireSafe(moduleName) {
+  try {
+    require.resolve(moduleName);
+    return require(moduleName);
+  } catch (err) {
+    return undefined;
+  }
+}
+
 var Promise = require('bluebird');
-var snappy  = require('snappy');
+var snappy  = requireSafe('snappy');
 var zlib    = require('zlib');
 var _ = require('lodash');
 
@@ -58,6 +67,9 @@ Gzip = {
 module.exports = {
     decompress: function (buffer, codec) {
         if (codec === 2) {
+            if (!snappy) {
+              return Promise.reject(new Error('Snappy is not installed. Please install it to use this codec.'));
+            }
             return Promise.resolve(Snappy.decompress(buffer));
         } else if (codec === 1 && typeof zlib.gunzipSync === 'function') {
             return Promise.resolve(Gzip.decompress(buffer));
@@ -67,6 +79,9 @@ module.exports = {
     },
     decompressAsync: function (buffer, codec) {
         if (codec === 2) {
+            if (!snappy) {
+                return Promise.reject(new Error('Snappy is not installed. Please install it to use this codec.'));
+            }
             return Snappy.decompressAsync(buffer);
         } else if (codec === 1) {
             return Gzip.decompressAsync(buffer);
@@ -76,6 +91,9 @@ module.exports = {
     },
     compress: function (buffer, codec) {
         if (codec === 2) {
+            if (!snappy) {
+              return Promise.reject(new Error('Snappy is not installed. Please install it to use this codec.'));
+            }
             return Promise.resolve(Snappy.compress(buffer));
         } else if (codec === 1 && typeof zlib.gzipSync === 'function') {
             return Promise.resolve(Gzip.compress(buffer));
@@ -84,6 +102,9 @@ module.exports = {
     },
     compressAsync: function (buffer, codec) {
         if (codec === 2) {
+            if (!snappy) {
+              return Promise.reject(new Error('Snappy is not installe. Please install it to use this codec.'));
+            }
             return Snappy.compressAsync(buffer);
         } else if (codec === 1) {
             return Gzip.compressAsync(buffer);

--- a/lib/protocol/misc/compression.js
+++ b/lib/protocol/misc/compression.js
@@ -1,18 +1,19 @@
 'use strict';
 
-var Promise = require('bluebird');
-var snappy  = requireSafe('snappy');
-var zlib    = require('zlib');
-var _ = require('lodash');
-
-function requireSafe(moduleName) {
+var requireSafe = function requireSafe(moduleName) {
     try {
         require.resolve(moduleName);
         return require(moduleName);
     } catch (err) {
         return undefined;
     }
-}
+};
+var Promise = require('bluebird');
+var snappy  = requireSafe('snappy');
+var zlib    = require('zlib');
+var _ = require('lodash');
+
+
 
 var SNAPPY_MAGIC_HEADER = new Buffer([-126, 83, 78, 65, 80, 80, 89, 0]); // '\x82SNAPPY\00'
 /*var SNAPPY_BLOCK_SIZE = 32 * 1024;

--- a/lib/protocol/misc/compression.js
+++ b/lib/protocol/misc/compression.js
@@ -13,8 +13,6 @@ var snappy  = requireSafe('snappy');
 var zlib    = require('zlib');
 var _ = require('lodash');
 
-
-
 var SNAPPY_MAGIC_HEADER = new Buffer([-126, 83, 78, 65, 80, 80, 89, 0]); // '\x82SNAPPY\00'
 /*var SNAPPY_BLOCK_SIZE = 32 * 1024;
 var SNAPPY_DEFAULT_VERSION = 1;

--- a/lib/protocol/misc/compression.js
+++ b/lib/protocol/misc/compression.js
@@ -20,7 +20,7 @@ var SNAPPY_MINIMUM_COMPATIBLE_VERSION = 1;*/
 
 var Snappy, Gzip;
 
-Snappy = {
+Snappy = snappy ? {
     _chunks: function (buffer) {
         var offset = 16, size, chunks = [];
         if (buffer.toString('hex', 0, 8) === SNAPPY_MAGIC_HEADER.toString('hex')) {
@@ -51,7 +51,7 @@ Snappy = {
     compress: snappy.compressSync,
 
     compressAsync: _.ary(Promise.promisify(snappy.compress), 1)
-};
+} : undefined;
 
 Gzip = {
     decompress: zlib.gunzipSync,
@@ -66,7 +66,7 @@ Gzip = {
 module.exports = {
     decompress: function (buffer, codec) {
         if (codec === 2) {
-            if (!snappy) {
+            if (!Snappy) {
                 return Promise.reject(new Error('Snappy is not installed. Please install it to use this codec.'));
             }
             return Promise.resolve(Snappy.decompress(buffer));
@@ -78,7 +78,7 @@ module.exports = {
     },
     decompressAsync: function (buffer, codec) {
         if (codec === 2) {
-            if (!snappy) {
+            if (!Snappy) {
                 return Promise.reject(new Error('Snappy is not installed. Please install it to use this codec.'));
             }
             return Snappy.decompressAsync(buffer);
@@ -90,7 +90,7 @@ module.exports = {
     },
     compress: function (buffer, codec) {
         if (codec === 2) {
-            if (!snappy) {
+            if (!Snappy) {
                 return Promise.reject(new Error('Snappy is not installed. Please install it to use this codec.'));
             }
             return Promise.resolve(Snappy.compress(buffer));
@@ -101,7 +101,7 @@ module.exports = {
     },
     compressAsync: function (buffer, codec) {
         if (codec === 2) {
-            if (!snappy) {
+            if (!Snappy) {
                 return Promise.reject(new Error('Snappy is not installe. Please install it to use this codec.'));
             }
             return Snappy.compressAsync(buffer);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "buffer-crc32": "^0.2.5",
     "nice-simple-logger": "^1.0.1",
     "hashring": "^3.2.0",
-    "wrr-pool": "^1.0.3",
+    "wrr-pool": "^1.0.3"
   },
   "optionalDependencies": {
     "snappy": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "nice-simple-logger": "^1.0.1",
     "hashring": "^3.2.0",
     "wrr-pool": "^1.0.3",
+  },
+  "optionalDependencies": {
     "snappy": "^5.0.0"
   },
   "devDependencies": {
@@ -29,7 +31,8 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
     "sinon": "^1.4.0",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "snappy": "^5.0.0"
   },
   "bugs": {
     "url": "https://github.com/oleksiyk/kafka/issues"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "hashring": "^3.2.0",
     "wrr-pool": "^1.0.3"
   },
-  "optionalDependencies": {
-    "snappy": "^5.0.0"
-  },
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",


### PR DESCRIPTION
We've had a lot of issues with Kafka and snappy in our Node.js development, primarily around Snappy's use of the node-gyp tooling. This change does a few things to address this:

- Removed (Move snappy to being a dev/optional dependency: removed completely due to way npm install works).
- Make module loader fail-safe when snappy is not installed.
- Change compression helper to reject promises when snappy is specified but not installed.
- Updated documentation to reflect this.

__Update__: Removed the optional dependency on snappy because when no-kafka is referenced by nested packages, the npm install --no-optional is all-or-nothing for the entire subtree.