### PR TITLE
Added periodic offset committing

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,26 @@ var strategies = [{
 consumer.init(strategies); // all done, now wait for messages in dataHandler
 ```
 
+## PeriodicOffsetCommitter
+
+Periodically commit offsets at a set interval (default 5 seconds).  Can perform better than calling 
+consumer.commitOffset for every message when processing a high volume of messages.
+ 
+ Example:
+ 
+ ```javascript
+ var Promise = require('bluebird');
+ var consumer = new Kafka.GroupConsumer();
+ var periodicOffsetCommitter = new Kafka.PeriodicOffsetCommitter(consumer);
+ 
+ var dataHandler = function (messageSet, topic, partition) {
+     return Promise.each(messageSet, function (m){
+         console.log(topic, partition, m.offset, m.message.value.toString('utf8'));
+         periodicOffsetCommitter.setOffset({topic: topic, partition: partition, offset: m.offset});
+     });
+ };
+ ````
+
 ### Assignment strategies
 
 __no-kafka__ provides three built-in strategies:

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ module.exports = (function () {
     exports.SimpleConsumer = require('./simple_consumer');
     exports.GroupConsumer = require('./group_consumer');
     exports.GroupAdmin = require('./group_admin');
+    exports.PeriodicOffsetCommitter = require('./periodic_offset_committer');
 
     // offset request time constants
     exports.EARLIEST_OFFSET = -2;

--- a/lib/periodic_offset_committer.js
+++ b/lib/periodic_offset_committer.js
@@ -1,0 +1,74 @@
+"use strict";
+var P = require('bluebird');
+
+function PeriodicOffsetCommitter(consumer, bunyanStyleLogger, interval, logDuration) {
+  if (!consumer) {
+    throw new Error("consumer is required");
+  }
+  this.interval = interval ? interval : 5000;
+  this.logDuration = logDuration ? logDuration : defaultLogDuration;
+  this.consumer = consumer;
+  this.log = bunyanStyleLogger;
+  this.topics = {};
+
+  if (this.log) this.log.debug("calling commitOffsetIfNeeded every " + this.interval + "ms");
+  setTimeout(commitOffsetIfNeeded.bind(this), this.interval);
+}
+
+PeriodicOffsetCommitter.prototype.setOffset = function(topic, partition, offset) {
+  if (this.log) this.log.debug({topic: topic, partition: partition, offset: offset}, "setOffset");
+  if (!this.topics[topic]) {
+    this.topics[topic] = {partitions: {}};
+  }
+  var partitions = this.topics[topic].partitions;
+  if (!partitions[partition]) {
+    partitions[partition] = -1;
+  }
+  if (offset > partitions[partition]) {
+    partitions[partition] = offset;
+  }
+};
+
+function commitOffsetIfNeeded() {
+  if (this.log) this.log.debug("commitOffsetIfNeeded");
+  var self = this;
+  var payloads = [];
+  for (var topicKey in this.topics) {
+    var partitions = this.topics[topicKey].partitions;
+    for (var partitionKey in partitions) {
+      var offset = partitions[partitionKey];
+      payloads.push({topic: topicKey, partition: parseInt(partitionKey), offset: offset});
+    }
+  }
+  return P.each(payloads, function(payload) {
+    return commitOffset(payload, self.consumer, self.log, self.logDuration);
+  })
+  .then(function() {
+    self.topics = {};
+    setTimeout(commitOffsetIfNeeded.bind(self), self.interval);
+  });
+}
+
+function commitOffset(payload, consumer, log, logDuration) {
+  var start = new Date();
+  return consumer.commitOffset(payload)
+    .then(function() {
+      if (log) log.info(payload, "consumer.commitOffset");
+    })
+    .catch(function(err) {
+      if (log) log.error(err);
+    })
+    .finally(function() {
+      if (log) logDuration(log, start, "consumer.commitOffset");
+    });
+}
+
+/**
+ * Default implementation of logging a duration.  Overrideable via the constructor
+ * because the specific format of a performance log likely differs per organization.
+ */
+function defaultLogDuration(log, start, label) {
+  log.info({duration: new Date().getTime() - start}, label);
+}
+
+module.exports = PeriodicOffsetCommitter;

--- a/test/test_periodic_offset_committer.js
+++ b/test/test_periodic_offset_committer.js
@@ -1,0 +1,82 @@
+var assert = require('chai').assert;
+var P = require('bluebird');
+var Kafka = require('../lib');
+
+var fakeConsumer = {};
+fakeConsumer.commits = [];
+fakeConsumer.commitOffset = function(payload) {
+  fakeConsumer.commits.push({topic: payload.topic, partition: payload.partition, offset: payload.offset});
+  var fakeThen = {};
+  fakeThen.then = function() {
+    var fakeCatch = {};
+    fakeCatch.catch = function(){
+      var fakeFinally = {};
+      fakeFinally.finally = function(){};
+      return fakeFinally;
+    };
+    return fakeCatch;
+  };
+  return fakeThen;
+}
+var fakeLog = {};
+fakeLog.debug = function(){};
+fakeLog.error = function(){};
+fakeLog.info = function(){};
+
+describe('PeriodicOffsetCommitter', function() {
+
+  describe('#constructor()', function () {
+    it('should create an object', function () {
+      var periodicOffsetCommitter = new Kafka.PeriodicOffsetCommitter(fakeConsumer, fakeLog);
+      assert.isNotNull(periodicOffsetCommitter, 'object should not be null');
+    });
+  });
+
+  describe('#constructor()', function () {
+    it('should throw an Error if required parameters are not passed', function () {
+      try {
+        new Kafka.PeriodicOffsetCommitter();
+        assert.fail('no error', 'error', 'expected an error to be thrown');
+      } catch (err) {
+        // expected
+        assert(true);
+      }
+    });
+  });
+
+  describe('#constructor()', function () {
+    it('should allow an optional interval parameter to be passed', function () {
+      var interval = 1000;
+      var periodicOffsetCommitter = new Kafka.PeriodicOffsetCommitter(fakeConsumer, fakeLog, interval);
+      assert.equal(periodicOffsetCommitter.interval, interval, 
+        'expected interval of ' + interval + ' but actual value was ' + periodicOffsetCommitter.interval);
+    });
+  });
+
+  describe('#setOffset()', function () {
+    it('should set the offset', function (done) {
+      var periodicOffsetCommitter = new Kafka.PeriodicOffsetCommitter(fakeConsumer, fakeLog, 100);
+      periodicOffsetCommitter.setOffset('topicA', 0, 10);
+      periodicOffsetCommitter.setOffset('topicA', 0, 11);
+      periodicOffsetCommitter.setOffset('topicB', 7, 1);
+      periodicOffsetCommitter.setOffset('topicB', 11, 1);
+      periodicOffsetCommitter.setOffset('topicB', 7, 5);
+      periodicOffsetCommitter.setOffset('topicA', 0, 9);
+      setTimeout(function() {
+
+        // wait to let the commitOffsetIfNeeded function get invoked
+        assert(Object.keys(periodicOffsetCommitter.topics).length === 0
+          && periodicOffsetCommitter.topics.constructor === Object,
+          'expected topics to be empty object');
+
+        // make sure the correct commits where made,
+        // only the highest offset per topic/partition should be committed
+        assert.deepEqual(fakeConsumer.commits[0], {topic: 'topicA', partition: 0, offset: 11});
+        assert.deepEqual(fakeConsumer.commits[1], {topic: 'topicB', partition: 7, offset: 5});
+        assert.deepEqual(fakeConsumer.commits[2], {topic: 'topicB', partition: 11, offset: 1});
+        done();
+      }, 500);
+    });
+  });
+
+});


### PR DESCRIPTION
One of the things I found during the course of performance testing was that, for my use case at least, the consumers performed better if committing the offset was done periodically vs for every single message.  So I wrote this pretty self-contained object to provide that capability.  May be useful to add to the library.