### PR TITLE
allow for custom logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,21 @@ In case of network error which prevents further operations __no-kafka__ will try
 
 ## Logging
 
+### Custom logger
+You can send in a log object (like [bunyan](https://www.npmjs.com/package/bunyan)):
+
+```javascript
+var bunyan = require('bunyan');
+var log = bunyan.createLogger({name: "Kafka"});
+
+var consumer = new Kafka.GroupConsumer({
+    clientId: 'group-consumer',
+    logger: log
+});
+```
+
+### Default logger
+
 You can differentiate messages from several instances of producer/consumer by providing unique `clientId` in options:
 
 ```javascript

--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,7 @@ var compression = require('./protocol/misc/compression');
 var url         = require('url');
 
 function Client(options) {
-    var self = this, logger;
+    var self = this, defaultLogger;
 
     self.options = _.defaultsDeep(options || {}, {
         clientId: 'no-kafka-client',
@@ -28,11 +28,14 @@ function Client(options) {
         }
     });
 
-    logger = new Logger(self.options.logger);
+    defaultLogger = new Logger(self.options.logger);
 
-    // prepend clientId argument
+    //For backwards compatibility we check if the logger object we send in contains
+    //any functions that we could use instead of our default logger
     ['log', 'debug', 'error', 'warn', 'trace'].forEach(function (m) {
-        self[m] = _.bind(logger[m], logger, self.options.clientId);
+        self[m] = (_.get(options.logger, m, false) && _.isFunction(options.logger[m])) ?
+            _.bind(options.logger[m], options.logger, self.options.clientId) :
+            _.bind(defaultLogger[m], defaultLogger, self.options.clientId);
     });
 
     self.protocol = new Protocol({


### PR DESCRIPTION
We use [bunyan](https://github.com/trentm/node-bunyan) for our logging needs but no-kafka only allowed us to send in 1 logFunction. This meant that we couldn't use log levels properly.

I've tried to remedy this by allowing you to pass in any object which overrides the standard logging functions. It's not as pretty as I would like it to be but I favoured backwards compatibility over my OCD ;-) Test could probably be expanded a bit more but think this covers the basics. README updated accordingly.

I haven't tested all the logging libraries, just bunyan but now my output looks beautiful :-) What do you think...worth merging?

![image](https://cloud.githubusercontent.com/assets/3949285/17976649/a2a313f6-6aee-11e6-84af-91bebdb98596.png)
