### PR TITLE
Fix bug due to Promise.then race condition and shallow buffer copy

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -178,7 +178,7 @@ Connection.prototype._receive = function (data) {
 
     this.offset = 0;
 
-    this.queue.shift().resolve(data.slice(4, length + 4));
+    this.queue.shift().resolve(Buffer.from(data.slice(4, length + 4)));
 
     if (data.length > 4 + length) {
         this._receive(data.slice(length + 4));


### PR DESCRIPTION
Hi,

I found in our integration tests that sometimes line 300 in client.js
`return self.protocol.read(responseBuffer).ProduceResponse().result.topics;`
threw an error that it was reading past the end of the buffer.

After exploring, I eventually worked out the problem: when multiple promises get resolved closely together, sometimes the .then of an earlier resolve executes after later resolves have been called. Since Buffer.slice is shallow copy, the "late" .then receives data from a different message. 

My fix is to deep-copy the buffer (rather than try to enforce .then execution order). Hopefully this is a good approach!