### PR TITLE
Added brokerRedirection capability.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -115,7 +115,7 @@ Client.prototype.parseHostString = function (hostString) {
 
     return {
         host: parsed.hostname,
-        port: parseInt(parsed.port),
+        port: parseInt(parsed.port)
     };
 };
 
@@ -127,7 +127,7 @@ Client.prototype.checkBrokerRedirect = function (host, port) {
     if (!redirect) {
         return {
             host,
-            port,
+            port
         };
     }
 
@@ -150,7 +150,7 @@ Client.prototype.checkBrokerRedirect = function (host, port) {
 
     return {
         host,
-        port,
+        port
     };
 };
 
@@ -158,7 +158,7 @@ Client.prototype.brokerNullRemap = function (host, port) {
     // Default function.
     return {
         host,
-        port,
+        port
     };
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,6 +16,7 @@ function Client(options) {
         clientId: 'no-kafka-client',
         connectionString: process.env.KAFKA_URL || 'kafka://127.0.0.1:9092',
         asyncCompression: false,
+        brokerRedirection: self.brokerNullRemap,
         reconnectionDelay: {
             min: 1000,
             max: 1000
@@ -76,17 +77,8 @@ Client.prototype.init = function () {
     self.initialBrokers = self.options.connectionString.split(',').map(function (hostStr) {
         var parsed, config;
 
-        hostStr = hostStr.trim();
-
-        if (!/^([a-z]+:)?\/\//.test(hostStr)) {
-            hostStr = 'kafka://' + hostStr;
-        }
-
-        parsed = url.parse(hostStr);
-        config = {
-            host: parsed.hostname,
-            port: parseInt(parsed.port)
-        };
+        parsed = self.parseHostString(hostStr);
+        config = self.checkBrokerRedirect(parsed.host, parsed.port);
 
         return config.host && config.port ? new Connection(config) : undefined;
     });
@@ -112,6 +104,64 @@ Client.prototype.end = function () {
         });
 };
 
+Client.prototype.parseHostString = function (hostString) {
+    var hostStr = hostString.trim(), parsed;
+
+    // Prepend the protocol, if required
+    if (!/^([a-z]+:)?\/\//.test(hostStr)) {
+        hostStr = 'kafka://' + hostStr;
+    }
+    parsed = url.parse(hostStr);
+
+    return {
+        host: parsed.hostname,
+        port: parseInt(parsed.port),
+    };
+};
+
+Client.prototype.checkBrokerRedirect = function (host, port) {
+    var self = this, fullName, fullNameProtocol;
+    var redirect = self.options.brokerRedirection;
+
+    // No remapper
+    if (!redirect) {
+        return {
+            host,
+            port,
+        };
+    }
+
+    // Use a function
+    if (typeof redirect === 'function') {
+        return redirect(host, port);
+    }
+
+    // Name, without protocol
+    fullName = host + ':' + port.toString();
+    if (redirect[fullName]) {
+        return this.parseHostString(redirect[fullName]);
+    }
+
+    // Name, with protocol
+    fullNameProtocol = 'kafka://' + host + ':' + port.toString();
+    if (redirect[fullNameProtocol]) {
+        return this.parseHostString(redirect[fullNameProtocol]);
+    }
+
+    return {
+        host,
+        port,
+    };
+};
+
+Client.prototype.brokerNullRemap = function (host, port) {
+    // Default function.
+    return {
+        host,
+        port,
+    };
+};
+
 Client.prototype.updateMetadata = function () {
     var self = this, attempt = 1;
 
@@ -130,12 +180,14 @@ Client.prototype.updateMetadata = function () {
             self.brokerConnections = {};
 
             _.each(response.broker, function (broker) {
+                var remapped = self.checkBrokerRedirect(broker.host, broker.port);
                 var connection = _.find(oldConnections, function (c, i) {
-                    return c.equal(broker.host, broker.port) && delete oldConnections[i];
+                    return c.equal(remapped.host, remapped.port) && delete oldConnections[i];
                 });
+
                 self.brokerConnections[broker.nodeId] = connection || new Connection({
-                    host: broker.host,
-                    port: broker.port
+                    host: remapped.host,
+                    port: remapped.port
                 });
             });
 
@@ -478,10 +530,8 @@ Client.prototype._findGroupCoordinator = function (groupId) {
         });
     }))
     .then(function (host) {
-        return new Connection({
-            host: host.coordinatorHost,
-            port: host.coordinatorPort
-        });
+        const remapped = self.checkBrokerRedirect(host.coordinatorHost, host.coordinatorPort);
+        return new Connection(remapped);
     })
     .catch(function (err) {
         if (err.length === 1) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -530,7 +530,7 @@ Client.prototype._findGroupCoordinator = function (groupId) {
         });
     }))
     .then(function (host) {
-        const remapped = self.checkBrokerRedirect(host.coordinatorHost, host.coordinatorPort);
+        var remapped = self.checkBrokerRedirect(host.coordinatorHost, host.coordinatorPort);
         return new Connection(remapped);
     })
     .catch(function (err) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -126,8 +126,8 @@ Client.prototype.checkBrokerRedirect = function (host, port) {
     // No remapper
     if (!redirect) {
         return {
-            host,
-            port
+            host: host,
+            port: port
         };
     }
 
@@ -149,16 +149,16 @@ Client.prototype.checkBrokerRedirect = function (host, port) {
     }
 
     return {
-        host,
-        port
+        host: host,
+        port: port
     };
 };
 
 Client.prototype.brokerNullRemap = function (host, port) {
     // Default function.
     return {
-        host,
-        port
+        host: host,
+        port: port
     };
 };
 

--- a/test/05.other.js
+++ b/test/05.other.js
@@ -63,8 +63,8 @@ describe('brokerRedirection', function () {
             brokerRedirection: function (host, port) {
                 latched = true;
                 return {
-                    host,
-                    port
+                    host: host,
+                    port: port
                 };
             }
         });

--- a/test/05.other.js
+++ b/test/05.other.js
@@ -64,9 +64,9 @@ describe('brokerRedirection', function () {
                 latched = true;
                 return {
                     host,
-                    port,
+                    port
                 };
-            },
+            }
         });
 
         return producer.init()
@@ -83,9 +83,9 @@ describe('brokerRedirection', function () {
                 latched = true;
                 return {
                     host: 'localhost',
-                    port: 9092,
+                    port: 9092
                 };
-            },
+            }
         });
 
         // If the init is succesful, then we remapped the bad
@@ -100,8 +100,8 @@ describe('brokerRedirection', function () {
         var producer = new Kafka.Producer({
             connectionString: 'does-not-exist:9092',
             brokerRedirection: {
-                'does-not-exist:9092': 'localhost:9092',
-            },
+                'does-not-exist:9092': 'localhost:9092'
+            }
         });
 
         // If the init is succesful, then we remapped the bad
@@ -113,8 +113,8 @@ describe('brokerRedirection', function () {
         var producer = new Kafka.Producer({
             connectionString: 'does-not-exist:9092',
             brokerRedirection: {
-                'kafka://does-not-exist:9092': 'localhost:9092',
-            },
+                'kafka://does-not-exist:9092': 'localhost:9092'
+            }
         });
 
         // If the init is succesful, then we remapped the bad
@@ -126,8 +126,8 @@ describe('brokerRedirection', function () {
         var producer = new Kafka.Producer({
             connectionString: 'does-not-exist:9092',
             brokerRedirection: {
-                'kafka://does-not-exist:9092': 'kafka://localhost:9092',
-            },
+                'kafka://does-not-exist:9092': 'kafka://localhost:9092'
+            }
         });
 
         // If the init is succesful, then we remapped the bad

--- a/test/05.other.js
+++ b/test/05.other.js
@@ -55,3 +55,83 @@ describe('connectionString', function () {
         return producer.init().should.be.rejected;
     });
 });
+
+describe('brokerRedirection', function () {
+    it('Should execute a function passed for direction', function () {
+        var latched = false;
+        var producer = new Kafka.Producer({
+            brokerRedirection: function (host, port) {
+                latched = true;
+                return {
+                    host,
+                    port,
+                };
+            },
+        });
+
+        return producer.init()
+            .then(function () {
+                latched.should.eql(true);
+            });
+    });
+
+    it('Should apply function remapping', function () {
+        var latched = false;
+        var producer = new Kafka.Producer({
+            connectionString: 'does-not-exist:9092',
+            brokerRedirection: function () {
+                latched = true;
+                return {
+                    host: 'localhost',
+                    port: 9092,
+                };
+            },
+        });
+
+        // If the init is succesful, then we remapped the bad
+        // broker name.
+        return producer.init()
+            .then(function () {
+                latched.should.eql(true);
+            });
+    });
+
+    it('Should apply lookup remap (host:port)', function () {
+        var producer = new Kafka.Producer({
+            connectionString: 'does-not-exist:9092',
+            brokerRedirection: {
+                'does-not-exist:9092': 'localhost:9092',
+            },
+        });
+
+        // If the init is succesful, then we remapped the bad
+        // broker name.
+        return producer.init();
+    });
+
+    it('Should apply lookup remap (kafka://host:port)', function () {
+        var producer = new Kafka.Producer({
+            connectionString: 'does-not-exist:9092',
+            brokerRedirection: {
+                'kafka://does-not-exist:9092': 'localhost:9092',
+            },
+        });
+
+        // If the init is succesful, then we remapped the bad
+        // broker name.
+        return producer.init();
+    });
+
+    it('Should apply lookup remap prefixed with Kafka', function () {
+        var producer = new Kafka.Producer({
+            connectionString: 'does-not-exist:9092',
+            brokerRedirection: {
+                'kafka://does-not-exist:9092': 'kafka://localhost:9092',
+            },
+        });
+
+        // If the init is succesful, then we remapped the bad
+        // broker name.
+        return producer.init();
+    });
+});


### PR DESCRIPTION
As per #113 - an example of how one might remap broker connections. Change includes:

- Default fall-through/no-op behaviour (no downstream impact for unexpecting users)
- The ability to pass a map of host/port remaps for simple 1:1 NAT.
- The ability to pass a function to remap the host/port pair for complex scenarios.
- Documentation
- Full test coverage
- Changes to externalise the kafka://host:port parsing into a function thats used commonly

This will dramatically simplify Docker/vagrant type development workflows where Kafka needs to have many conflicting addresses.

__Update__: Was complying (on autopilot) with the eslint 'comma-dangle' rule that's prevalent in the airbnb profile. This chokes out Node 0.x, so I've removed it.