### PR TITLE
Report topic and partition in producer errors

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -255,7 +255,7 @@ Client.prototype.getTopicPartitions = function (topic) {
         if (self.topicMetadata.hasOwnProperty(topic)) {
             return self.topicMetadata[topic];
         }
-        throw errors.byName('UnknownTopicOrPartition');
+        throw errors.byName('UnknownTopicOrPartition', { topic: topic });
     }
 
     return self._waitMetadata().then(_try)
@@ -271,10 +271,10 @@ Client.prototype.findLeader = function (topic, partition, notfoundOK) {
     function _try() {
         var r = _.get(self.topicMetadata, [topic, partition, 'leader'], notfoundOK ? parseInt(_.keys(self.brokerConnections)[0]) : -1);
         if (r === -1) {
-            throw errors.byName('UnknownTopicOrPartition');
+            throw errors.byName('UnknownTopicOrPartition', { topic: topic, partition: partition });
         }
         if (!self.brokerConnections[r]) {
-            throw errors.byName('LeaderNotAvailable');
+            throw errors.byName('LeaderNotAvailable', { topic: topic, partition: partition });
         }
         return r;
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -38,9 +38,10 @@ var errors = [
     ['ClusterAuthorizationFailed', 31, 'Returned by the broker when the client is not authorized to use an inter-broker or administrative API.']
 ];
 
-function KafkaError(code, message) {
+function KafkaError(code, message, props) {
     // Error.captureStackTrace(this, this.constructor);
 
+    _.assign(this, props);
     this.name = this.constructor.name;
     this.code = code;
     this.message = message || 'Error';
@@ -65,7 +66,7 @@ KafkaError.prototype.toString = function () {
 };
 
 
-exports.byCode = function (code) {
+exports.byCode = function (code, props) {
     var error;
 
     if (code === 0) {
@@ -80,10 +81,10 @@ exports.byCode = function (code) {
         return new Error('Unknown error code: ' + code);
     }
 
-    return new KafkaError(error[0], error[2]);
+    return new KafkaError(error[0], error[2], props);
 };
 
-exports.byName = function (name) {
+exports.byName = function (name, props) {
     var error = _.find(errors, function (e) {
         return e[0] === name;
     });
@@ -92,7 +93,7 @@ exports.byName = function (name) {
         return null; // no error
     }
 
-    return new KafkaError(error[0], error[2]);
+    return new KafkaError(error[0], error[2], props);
 };
 
 function NoKafkaConnectionError(server, message) {

--- a/test/01.producer.js
+++ b/test/01.producer.js
@@ -110,7 +110,7 @@ describe('Producer', function () {
         });
     });
 
-    it('should return an error for unknown partition/topic and retry 5 times', function () {
+    it.only('should return an error for unknown partition/topic and retry 5 times', function () {
         var start = Date.now(), msgs;
         msgs = [{
             topic: 'kafka-test-unknown-topic',
@@ -134,6 +134,8 @@ describe('Producer', function () {
             result[1].should.have.property('error');
             result[0].error.should.have.property('code', 'UnknownTopicOrPartition');
             result[1].error.should.have.property('code', 'UnknownTopicOrPartition');
+            result[0].error.should.have.property('topic', 'kafka-test-unknown-topic');
+            result[1].error.should.have.property('topic', 'kafka-test-unknown-topic');
             (Date.now() - start).should.be.closeTo(500, 100);
         });
     });


### PR DESCRIPTION
Hello.

Was trying to attach topic and partition to the producer errors. Couldn't implement that successfully. This could be a handy feature for debugging which exactly part of a consumer-producer queue is failing.

Any chance to get help with that? The `it.only()` test fails. :\
