### PR TITLE
Update chai and mocha to fix warnings on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "chai-as-promised": "^5.2.0",
+    "chai-as-promised": "^6.0.0",
     "eslint": "^2.2.0",
     "eslint-config-magictoolbox": "^0.0.2",
     "istanbul": "^0.4.2",
-    "mocha": "^2.4.5",
+    "mocha": "^3.1.2",
     "sinon": "^1.4.0",
     "sinon-chai": "^2.8.0",
     "snappy": "^5.0.0"


### PR DESCRIPTION
Currently I get the following on `npm install`:
```
npm WARN deprecated to-iso-string@0.0.2: to-iso-string has been deprecated, use @segment/to-iso-string instead.
npm WARN deprecated jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

Updating chai and mocha removes this.  ESLint is more difficult to upgrade as it is a peer dependecy of eslint-config-magictoolbox which would need to be updated at the same time.  ESLint does not currently generate security warnings.