### PR TITLE
Update lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bluebird": "^3.3.3",
     "buffer-crc32": "^0.2.5",
     "hashring": "^3.2.0",
-    "lodash": "^4.16.4",
+    "lodash": "=4.16.4",
     "nice-simple-logger": "^1.0.1",
     "wrr-pool": "^1.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "kafka"
   ],
   "dependencies": {
-    "bluebird": "^3.3.3",
-    "lodash": "=4.5.0",
     "bin-protocol": "^3.0.2",
+    "bluebird": "^3.3.3",
     "buffer-crc32": "^0.2.5",
-    "nice-simple-logger": "^1.0.1",
     "hashring": "^3.2.0",
+    "lodash": "^4.16.4",
+    "nice-simple-logger": "^1.0.1",
     "wrr-pool": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
In issue https://github.com/oleksiyk/kafka/issues/124 the lodash version was fixed at 4.5.0 to avoid a regression in `merge` (https://github.com/lodash/lodash/issues/2699).

This has now been fixed, and testing no-kafka with 4.16.4 confirms this.
