### PR TITLE
Connect retry limit

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,6 +18,7 @@ function Client(options) {
         asyncCompression: false,
         brokerRedirection: false,
         reconnectionDelay: {
+            retries: 0,
             min: 1000,
             max: 1000
         },
@@ -207,6 +208,11 @@ Client.prototype.updateMetadata = function () {
             return null;
         })
         .catch(function (err) {
+            if (self.options.reconnectionDelay.retries > 0 &&
+                attempt >= self.options.reconnectionDelay.retries) {
+                return Promise.reject(err);
+            }
+
             var delay = _.min([attempt++ * self.options.reconnectionDelay.min, self.options.reconnectionDelay.max]);
             self.error('Metadata request failed:', err);
             return Promise.delay(delay).then(_try);

--- a/lib/client.js
+++ b/lib/client.js
@@ -208,6 +208,7 @@ Client.prototype.updateMetadata = function () {
             return null;
         })
         .catch(function (err) {
+            var delay;
             if (self.options.reconnectionDelay.retries > 0 &&
                 attempt >= self.options.reconnectionDelay.retries) {
                 self._updateMetadata_running = Promise.resolve();
@@ -215,7 +216,7 @@ Client.prototype.updateMetadata = function () {
                 return Promise.reject(err);
             }
 
-            var delay = _.min([attempt++ * self.options.reconnectionDelay.min, self.options.reconnectionDelay.max]);
+            delay = _.min([attempt++ * self.options.reconnectionDelay.min, self.options.reconnectionDelay.max]);
             self.error('Metadata request failed:', err);
             return Promise.delay(delay).then(_try);
         });

--- a/lib/client.js
+++ b/lib/client.js
@@ -210,6 +210,8 @@ Client.prototype.updateMetadata = function () {
         .catch(function (err) {
             if (self.options.reconnectionDelay.retries > 0 &&
                 attempt >= self.options.reconnectionDelay.retries) {
+                self._updateMetadata_running = Promise.resolve();
+                self._updateMetadata_running = self.updateMetadata();
                 return Promise.reject(err);
             }
 


### PR DESCRIPTION
The following works this way for Producers:
1) The driver continuously tries to (re)connect to Kafka when calling `producer.send()`.
2) After every `retry` attempt it rejects an error. Typically 

```
{ [NoKafkaConnectionError: Error: connect ECONNREFUSED]
  name: 'NoKafkaConnectionError',
  server: '127.0.0.1:9092',
  message: 'Error: connect ECONNREFUSED' }
```

3) As soon as connectivity is back everything goes back to normal.

This new `retry` should be used carefully with Consumers though. Because after the `retry` number of attempts it will reject and never attempt to reconnect.
# 

Producer Example 1.
Reject an error every ~3 seconds when you are trying to `producer.send()`

```
reconnectionDelay: {retries: 3}
```

Producer Example 2.
These configurations make no changes from the current no-kafka behavior:

```
reconnectionDelay: undefiend
reconnectionDelay: {retries: 0}
```
# 

Consumer Example 1.
Reject an error after ~3 seconds and never attempt to reconnect.

```
reconnectionDelay: {retries: 3}
```

Consumer Example 2.
Trying to reconnect forever. No changes from the current no-kafka behavior:

```
reconnectionDelay: undefiend
reconnectionDelay: {retries: 0}
```
# 

I tested it back and forth on my 2 node.js processes. Works as expected.

If you think we should give this a go I'll be happy to continue working on this PR (tests, README, etc.)
