### PR TITLE
Bugfixes preventing usage with Heroku Kafka

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -147,7 +147,7 @@ Client.prototype.parseHostString = function (hostString) {
     var hostStr = hostString.trim(), parsed;
 
     // Prepend the protocol, if required
-    if (!/^([a-z]+:)?\/\//.test(hostStr)) {
+    if (!/^([a-z+]+:)?\/\//.test(hostStr)) {
         hostStr = 'kafka://' + hostStr;
     }
     parsed = url.parse(hostStr);

--- a/test/08.connection.js
+++ b/test/08.connection.js
@@ -100,4 +100,34 @@ describe('Connection', function () {
             p.client.initialBrokers[1].server().should.be.eql('localhost:9092');
         });
     });
+
+    it('should parse connection string with + in the protocol', function () {
+        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092', ssl: { certFile: null, keyFile: null } });
+
+        return p.init().then(function () {
+            p.client.initialBrokers.should.be.an('array').and.have.length(1);
+            p.client.initialBrokers[0].server().should.be.eql('127.0.0.1:9092');
+        });
+    });
+
+    it('should parse connection string with multiple hosts with + in the protocol', function () {
+        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092,kafka+ssl://127.0.0.1:9092', ssl: { certFile: null, keyFile: null } });
+
+        return p.init().then(function () {
+            p.client.initialBrokers.should.be.an('array').and.have.length(2);
+            p.client.initialBrokers[0].server().should.be.eql('127.0.0.1:9092');
+            p.client.initialBrokers[1].server().should.be.eql('127.0.0.1:9092');
+        });
+    });
+
+    it('should parse connection string with hosts with and without + in the protocol', function () {
+        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092,kafka://127.0.0.1:9092,127.0.0.1:9092', ssl: { certFile: null, keyFile: null } });
+
+        return p.init().then(function () {
+            p.client.initialBrokers.should.be.an('array').and.have.length(3);
+            p.client.initialBrokers[0].server().should.be.eql('127.0.0.1:9092');
+            p.client.initialBrokers[1].server().should.be.eql('127.0.0.1:9092');
+            p.client.initialBrokers[2].server().should.be.eql('127.0.0.1:9092');
+        });
+    });
 });

--- a/test/08.connection.js
+++ b/test/08.connection.js
@@ -102,7 +102,7 @@ describe('Connection', function () {
     });
 
     it('should parse connection string with + in the protocol', function () {
-        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092', ssl: { certFile: null, keyFile: null } });
+        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(1);
@@ -111,7 +111,7 @@ describe('Connection', function () {
     });
 
     it('should parse connection string with multiple hosts with + in the protocol', function () {
-        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092,kafka+ssl://127.0.0.1:9092', ssl: { certFile: null, keyFile: null } });
+        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092,kafka+ssl://127.0.0.1:9092', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(2);
@@ -121,7 +121,7 @@ describe('Connection', function () {
     });
 
     it('should parse connection string with hosts with and without + in the protocol', function () {
-        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092,kafka://127.0.0.1:9092,127.0.0.1:9092', ssl: { certFile: null, keyFile: null } });
+        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092,kafka://127.0.0.1:9092,127.0.0.1:9092', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(3);


### PR DESCRIPTION
This contains 2 bugfixes which prevent this library to be used with the heroku kafka service

1. Heroku kafka puts the actual certificate and key in the env variables `KAFKA_CLIENT_CERT` and `KAFKA_CLIENT_CERT_KEY` rather than pathnames.
Due to how the default config variables are populated this means that no-kafka will always try to look for a cert file at an non-existing location and hence fail to connect.
I've added an additional check which prevents no-kafka from looking up certificates on disk if `ssl.cert` and `ssl.key` are already set by the user

2. Heroku kafka uses a protocol of the form `kafka+ssl://` in the connectionString. The regex used by no-kafka doesn't capture this and prefixes an additional `kafka://` protocol, preventing the client from resolving the actual host.
I updated the regex and added some tests for this case

I could not find any tests for the ssl connection, so I didn't add any there.