### PR TITLE
Do not overwrite user supplied ssl certificates and keys

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,14 +13,20 @@ var fs          = require('fs');
 function Client(options) {
     var self = this, logger;
 
-    self.options = _.defaultsDeep(options || {}, {
-        clientId: 'no-kafka-client',
-        connectionString: process.env.KAFKA_URL || 'kafka://127.0.0.1:9092',
+    // Do not overwrite user supplied ssl configuration
+    self.options = _.defaults(options || {}, {
         ssl: {
             certFile: process.env.KAFKA_CLIENT_CERT,
             keyFile: process.env.KAFKA_CLIENT_CERT_KEY,
             certStr: process.env.KAFKA_CLIENT_CERT_STR,
             keyStr: process.env.KAFKA_CLIENT_CERT_KEY_STR,
+        }
+    });
+
+    self.options = _.defaultsDeep(self.options, {
+        clientId: 'no-kafka-client',
+        connectionString: process.env.KAFKA_URL || 'kafka://127.0.0.1:9092',
+        ssl: {
             // secureProtocol: 'TLSv1_method',
             rejectUnauthorized: false,
             // ciphers: 'DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-SHA256:AES128-SHA:AES256-SHA256:AES256-SHA:RC4-SHA'

--- a/test/05.other.js
+++ b/test/05.other.js
@@ -56,6 +56,38 @@ describe('connectionString', function () {
     });
 });
 
+describe('ssl configuration', function () {
+    it('should set defaults for the ssl configuration', function () {
+        var expectedOptions = {
+            rejectUnauthorized: false,
+            certFile: process.env.KAFKA_CLIENT_CERT,
+            keyFile: process.env.KAFKA_CLIENT_CERT_KEY,
+            certStr: process.env.KAFKA_CLIENT_CERT_STR,
+            keyStr: process.env.KAFKA_CLIENT_CERT_KEY_STR,
+        };
+        var producer = new Kafka.Producer();
+        producer.client.options.ssl.should.be.an('object');
+        producer.client.options.ssl.should.contain.all.keys(expectedOptions);
+    });
+
+    it('should not set additional cert and key parameters if the user provided them', function () {
+        var expectedOptions = {
+            rejectUnauthorized: false,
+            certStr: process.env.KAFKA_CLIENT_CERT_STR,
+            keyStr: process.env.KAFKA_CLIENT_CERT_KEY_STR,
+        };
+        var producer = new Kafka.Producer({
+            ssl: {
+                certStr: process.env.KAFKA_CLIENT_CERT_STR,
+                keyStr: process.env.KAFKA_CLIENT_CERT_KEY_STR
+            }
+        });
+        producer.client.options.ssl.should.be.an('object');
+        producer.client.options.ssl.should.contain.all.keys(expectedOptions);
+        producer.client.options.ssl.should.not.contain.any.keys(['certFile', 'keyFile']);
+    });
+});
+
 describe('brokerRedirection', function () {
     it('Should execute a function passed for direction', function () {
         var latched = false;


### PR DESCRIPTION
I changed the way client.js sets default values for the ssl keys.
If a user has supplied an ssl object, no default values for `certStr`, `certFile`, `keyStr` and `keyFile` will be written.
This avoids the case where a user tries to set certStr equal to KAFKA_CLIENT_CERT (which is the default on the heroku platform) and no-kafka then still populates certFile and tries to load things from disk.

The edge case with this implementation is that if a user supplies an ssl config object, but no certs or keys no default values will be picked.
However I think this is much less likely than the current case. (so better usability and less tickets for you)

I also added two tests for this behaviour.