### PR TITLE
New simplified ssl options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 env:
   - CXX=g++-4.8
   - CXX=g++-4.8 KAFKA_URL=kafka://127.0.0.1:9093 KAFKA_CLIENT_CERT=${TRAVIS_BUILD_DIR}/test/ssl/client.crt KAFKA_CLIENT_CERT_KEY=${TRAVIS_BUILD_DIR}/test/ssl/client.key
-  - CXX=g++-4.8 KAFKA_URL=kafka://127.0.0.1:9093 KAFKA_CLIENT_CERT_STR="`cat ${TRAVIS_BUILD_DIR}/test/ssl/client.crt`" KAFKA_CLIENT_CERT_KEY_STR="`cat ${TRAVIS_BUILD_DIR}/test/ssl/client.key`"
+  # - CXX=g++-4.8 KAFKA_URL=kafka://127.0.0.1:9093 KAFKA_CLIENT_CERT_STR="`cat ${TRAVIS_BUILD_DIR}/test/ssl/client.crt`" KAFKA_CLIENT_CERT_KEY_STR="`cat ${TRAVIS_BUILD_DIR}/test/ssl/client.key`"
 
 addons:
   # code_climate:

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ __no-kafka__ will connect to the hosts specified in `connectionString` construct
 All network errors are handled by the library: producer will retry sending failed messages for configured amount of times, simple consumer and group consumer will try to reconnect to failed host, update metadata as needed as so on.
 
 ### SSL
-To connect to Kafka with [SSL endpoint enabled](http://kafka.apache.org/090/documentation.html#security_ssl) specify SSL certificate and key file options to load cert/key from files or provide certificate/key as strings:
+To connect to Kafka with [SSL endpoint enabled](http://kafka.apache.org/090/documentation.html#security_ssl) specify SSL certificate and key options to load cert/key from files or provide certificate/key directly as strings:
 
 Loading certificate and key from file:
 
@@ -496,8 +496,8 @@ Loading certificate and key from file:
 var producer = new Kafka.Producer({
   connectionString: 'kafka://127.0.0.1:9093', // should match `listeners` SSL option in Kafka config
   ssl: {
-    certFile: '/path/to/client.crt',
-    keyFile: '/path/to/client.key'
+    cert: '/path/to/client.crt',
+    key: '/path/to/client.key'
   }
 });
 ```
@@ -508,22 +508,24 @@ Specifying certificate and key directly as strings:
 var producer = new Kafka.Producer({
   connectionString: 'kafka://127.0.0.1:9093', // should match `listeners` SSL option in Kafka config
   ssl: {
-    certStr: '-----BEGIN CERTIFICATE-----\nMIIChTCCAe4C...............',
-    keyStr: '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBA.......'
+    cert: '-----BEGIN CERTIFICATE-----\nMIIChTCCAe4C...............',
+    key: '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBA.......'
   }
 });
 ```
 
 Other Node.js SSL options are available such as `rejectUnauthorized`, `secureProtocol`, `ciphers`, etc. See Node.js `tls.createServer` method documentation for more details.
 
-It is also possible to use `KAFKA_CLIENT_CERT`/`KAFKA_CLIENT_CERT_STR` and `KAFKA_CLIENT_CERT_KEY`/`KAFKA_CLIENT_CERT_KEY_STR` environment variables to specify SSL certificate and key:
+It is also possible to use `KAFKA_CLIENT_CERT` and `KAFKA_CLIENT_CERT_KEY` environment variables to specify SSL certificate and key:
 
 ```bash
 KAFKA_URL=kafka://127.0.0.1:9093 KAFKA_CLIENT_CERT=./test/ssl/client.crt KAFKA_CLIENT_CERT_KEY=./test/ssl/client.key node producer.js
 ```
 
+Or as text strings:
+
 ```bash
-KAFKA_URL=kafka://127.0.0.1:9093 KAFKA_CLIENT_CERT_STR=`cat ./test/ssl/client.crt` KAFKA_CLIENT_CERT_KEY_STR=`cat ./test/ssl/client.key` node producer.js
+KAFKA_URL=kafka://127.0.0.1:9093 KAFKA_CLIENT_CERT=`cat ./test/ssl/client.crt` KAFKA_CLIENT_CERT_KEY=`cat ./test/ssl/client.key` node producer.js
 ```
 
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,10 +17,8 @@ function Client(options) {
         clientId: 'no-kafka-client',
         connectionString: process.env.KAFKA_URL || 'kafka://127.0.0.1:9092',
         ssl: {
-            certFile: process.env.KAFKA_CLIENT_CERT,
-            keyFile: process.env.KAFKA_CLIENT_CERT_KEY,
-            certStr: process.env.KAFKA_CLIENT_CERT_STR,
-            keyStr: process.env.KAFKA_CLIENT_CERT_KEY_STR,
+            cert: process.env.KAFKA_CLIENT_CERT,
+            key: process.env.KAFKA_CLIENT_CERT_KEY,
             // secureProtocol: 'TLSv1_method',
             rejectUnauthorized: false,
             // ciphers: 'DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-SHA256:AES128-SHA:AES256-SHA256:AES256-SHA:RC4-SHA'
@@ -84,18 +82,29 @@ function _mapTopics(topics) {
 Client.prototype.init = function () {
     var self = this, p = Promise.resolve(), readFile = Promise.promisify(fs.readFile);
 
+    // deprecated but backward compatible ssl cert/key options
     if (self.options.ssl.certFile && self.options.ssl.keyFile) {
-        p = Promise.all([
-            readFile(self.options.ssl.certFile),
-            readFile(self.options.ssl.keyFile)
-        ])
-        .spread(function (cert, key) {
-            self.options.ssl.cert = cert;
-            self.options.ssl.key = key;
-        });
+        self.options.ssl.cert = self.options.ssl.certFile;
+        self.options.ssl.key = self.options.ssl.keyFile;
     } else if (self.options.ssl.certStr && self.options.ssl.keyStr) {
         self.options.ssl.cert = self.options.ssl.certStr;
         self.options.ssl.key = self.options.ssl.keyStr;
+    } else if (process.env.KAFKA_CLIENT_CERT_STR && process.env.KAFKA_CLIENT_CERT_KEY_STR) {
+        self.options.ssl.cert = process.env.KAFKA_CLIENT_CERT_STR;
+        self.options.ssl.key = process.env.KAFKA_CLIENT_CERT_KEY_STR;
+    }
+
+    if (self.options.ssl.cert && self.options.ssl.key) {
+        if (!/^-----BEGIN/.test(self.options.ssl.cert.toString('utf8'))) {
+            p = Promise.all([
+                readFile(self.options.ssl.cert),
+                readFile(self.options.ssl.key)
+            ])
+            .spread(function (cert, key) {
+                self.options.ssl.cert = cert;
+                self.options.ssl.key = key;
+            });
+        }
     }
 
     return p.then(function () {

--- a/test/08.connection.js
+++ b/test/08.connection.js
@@ -54,7 +54,7 @@ describe('Connection', function () {
     });
 
     it('should parse connection string with protocol', function () {
-        var p = new Kafka.Producer({ connectionString: 'kafka://127.0.0.1:9092', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
+        var p = new Kafka.Producer({ connectionString: 'kafka://127.0.0.1:9092', ssl: { cert: null, key: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(1);
@@ -63,7 +63,7 @@ describe('Connection', function () {
     });
 
     it('should parse connection string without protocol', function () {
-        var p = new Kafka.Producer({ connectionString: '127.0.0.1:9092', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
+        var p = new Kafka.Producer({ connectionString: '127.0.0.1:9092', ssl: { cert: null, key: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(1);
@@ -72,7 +72,7 @@ describe('Connection', function () {
     });
 
     it('should parse connection string with multiple hosts with and without protocol', function () {
-        var p = new Kafka.Producer({ connectionString: 'kafka://127.0.0.1:9092,127.0.0.1:9092', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
+        var p = new Kafka.Producer({ connectionString: 'kafka://127.0.0.1:9092,127.0.0.1:9092', ssl: { cert: null, key: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(2);
@@ -82,7 +82,7 @@ describe('Connection', function () {
     });
 
     it('should parse connection string with multiple hosts without protocol', function () {
-        var p = new Kafka.Producer({ connectionString: '127.0.0.1:9092,127.0.0.1:9092', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
+        var p = new Kafka.Producer({ connectionString: '127.0.0.1:9092,127.0.0.1:9092', ssl: { cert: null, key: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(2);
@@ -92,7 +92,7 @@ describe('Connection', function () {
     });
 
     it('should strip whitespaces in connectionString', function () {
-        var p = new Kafka.Producer({ connectionString: ' kafka://127.0.0.1:9092, localhost:9092 ', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
+        var p = new Kafka.Producer({ connectionString: ' kafka://127.0.0.1:9092, localhost:9092 ', ssl: { cert: null, key: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(2);
@@ -102,7 +102,7 @@ describe('Connection', function () {
     });
 
     it('should parse connection string with + in the protocol', function () {
-        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
+        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092', ssl: { cert: null, key: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(1);
@@ -111,7 +111,7 @@ describe('Connection', function () {
     });
 
     it('should parse connection string with multiple hosts with + in the protocol', function () {
-        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092,kafka+ssl://127.0.0.1:9092', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
+        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092,kafka+ssl://127.0.0.1:9092', ssl: { cert: null, key: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(2);
@@ -121,7 +121,7 @@ describe('Connection', function () {
     });
 
     it('should parse connection string with hosts with and without + in the protocol', function () {
-        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092,kafka://127.0.0.1:9092,127.0.0.1:9092', ssl: { certFile: null, keyFile: null, certStr: null, keyStr: null } });
+        var p = new Kafka.Producer({ connectionString: 'kafka+ssl://127.0.0.1:9092,kafka://127.0.0.1:9092,127.0.0.1:9092', ssl: { cert: null, key: null } });
 
         return p.init().then(function () {
             p.client.initialBrokers.should.be.an('array').and.have.length(3);


### PR DESCRIPTION
Replaces `certFile/keyFile` and `certStr/keyStr` with unified `cert/key` options. Maintains backward compatibility with old options.