### PR TITLE
Add an ability to check consumer lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,12 +388,13 @@ You can also write your own assignment strategy by inheriting from Kafka.Default
 
 ## GroupAdmin (consumer groups API)
 
-Offes two methods:
+Offers methods:
 
 * `listGroups` - list existing consumer groups
 * `describeGroup` - describe existing group by its id
+* `fetchConsumerLag` - fetches consumer lag for topics/partitions
 
-Example:
+listGroups, describeGroup:
 
 ```javascript
 var admin = new Kafka.GroupAdmin();
@@ -429,6 +430,38 @@ return admin.init().then(function(){
     });
 });
 ```
+
+fetchConsumerLag:
+```javascript
+var admin = new Kafka.GroupAdmin();
+
+return admin.init().then(function(){
+    return admin.fetchConsumerLag('no-kafka-admin-test-group', [{
+        topicName: 'kafka-test-topic',
+        partitions: [0, 1, 2]
+    }]).then(function (consumerLag) {
+        /*
+        [ { topic: 'kafka-test-topic',
+            partition: 0,
+            offset: 11300,
+            highwaterMark: 11318,
+            consumerLag: 18 },
+          { topic: 'kafka-test-topic',
+            partition: 1,
+            offset: 10380,
+            highwaterMark: 10380,
+            consumerLag: 0 },
+          { topic: 'kafka-test-topic',
+            partition: 2,
+            offset: -1,
+            highwaterMark: 10435,
+            consumerLag: null } ]
+         */
+    });
+});
+```
+
+Note that group consumer has to commit offsets first, in order for consumerLag to be available. Otherwise the offset will be set to -1.
 
 ## Compression
 

--- a/lib/base_consumer.js
+++ b/lib/base_consumer.js
@@ -92,7 +92,7 @@ BaseConsumer.prototype._partitionError = function (err, topic, partition) {
 
     if (err.code === 'OffsetOutOfRange') { // update partition offset to options.recoveryOffset
         self.client.warn('Updating offset because of OffsetOutOfRange error for', topic + ':' + partition);
-        return self.client.getOffset(s.leader, topic, partition, null, self.options.recoveryOffset).then(function (offset) {
+        return self.client.getPartitionOffset(s.leader, topic, partition, null, self.options.recoveryOffset).then(function (offset) {
             s.offset = offset;
         });
     } else if (err.code === 'MessageSizeTooLarge') {
@@ -142,7 +142,7 @@ BaseConsumer.prototype.offset = function (topic, partition, time) {
     partition = partition || 0;
 
     return self.client.findLeader(topic, partition).then(function (leader) {
-        return self.client.getOffset(leader, topic, partition, time);
+        return self.client.getPartitionOffset(leader, topic, partition, time);
     });
 };
 
@@ -204,7 +204,7 @@ BaseConsumer.prototype.subscribe = function (topic, partitions, options, handler
             if (options.offset >= 0) {
                 return _subscribe(partition, leader, options.offset);
             }
-            return self.client.getOffset(leader, topic, partition, options.time).then(function (offset) {
+            return self.client.getPartitionOffset(leader, topic, partition, options.time).then(function (offset) {
                 return _subscribe(partition, leader, offset);
             });
         })

--- a/lib/base_consumer.js
+++ b/lib/base_consumer.js
@@ -92,7 +92,7 @@ BaseConsumer.prototype._partitionError = function (err, topic, partition) {
 
     if (err.code === 'OffsetOutOfRange') { // update partition offset to options.recoveryOffset
         self.client.warn('Updating offset because of OffsetOutOfRange error for', topic + ':' + partition);
-        return self._offset(s.leader, topic, partition, null, self.options.recoveryOffset).then(function (offset) {
+        return self.client.getOffset(s.leader, topic, partition, null, self.options.recoveryOffset).then(function (offset) {
             s.offset = offset;
         });
     } else if (err.code === 'MessageSizeTooLarge') {
@@ -128,27 +128,6 @@ BaseConsumer.prototype._updateSubscription = function (topic, partition) {
     });
 };
 
-BaseConsumer.prototype._offset = function (leader, topic, partition, time) {
-    var self = this, request = {};
-
-    request[leader] = [{
-        topicName: topic,
-        partitions: [{
-            partition: partition,
-            time: time || Kafka.LATEST_OFFSET, // the latest (next) offset by default
-            maxNumberOfOffsets: 1
-        }]
-    }];
-
-    return self.client.offsetRequest(request).then(function (result) {
-        var p = result[0];
-        if (p.error) {
-            throw p.error;
-        }
-        return p.offset[0];
-    });
-};
-
 /**
  * Get offset for specified topic/partition and time
  *
@@ -163,7 +142,7 @@ BaseConsumer.prototype.offset = function (topic, partition, time) {
     partition = partition || 0;
 
     return self.client.findLeader(topic, partition).then(function (leader) {
-        return self._offset(leader, topic, partition, time);
+        return self.client.getOffset(leader, topic, partition, time);
     });
 };
 
@@ -225,7 +204,7 @@ BaseConsumer.prototype.subscribe = function (topic, partitions, options, handler
             if (options.offset >= 0) {
                 return _subscribe(partition, leader, options.offset);
             }
-            return self._offset(leader, topic, partition, options.time).then(function (offset) {
+            return self.client.getOffset(leader, topic, partition, options.time).then(function (offset) {
                 return _subscribe(partition, leader, offset);
             });
         })

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,7 @@ var Logger      = require('nice-simple-logger');
 var compression = require('./protocol/misc/compression');
 var url         = require('url');
 var fs          = require('fs');
+var Kafka       = require('./index');
 
 function Client(options) {
     var self = this, logger;
@@ -476,6 +477,27 @@ Client.prototype.offsetRequest = function (requests) {
             });
         }))
         .then(_mapTopics);
+    });
+};
+
+Client.prototype.getOffset = function (leader, topic, partition, time) {
+    var request = {};
+
+    request[leader] = [{
+        topicName: topic,
+        partitions: [{
+            partition: partition,
+            time: time || Kafka.LATEST_OFFSET, // the latest (next) offset by default
+            maxNumberOfOffsets: 1
+        }]
+    }];
+
+    return this.offsetRequest(request).then(function (result) {
+        var p = result[0];
+        if (p.error) {
+            throw p.error;
+        }
+        return p.offset[0];
     });
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -460,27 +460,7 @@ Client.prototype.fetchRequest = function (requests) {
     });
 };
 
-Client.prototype.offsetRequest = function (requests) {
-    var self = this;
-
-    return self._waitMetadata().then(function () {
-        return Promise.all(_.map(requests, function (topics, leader) {
-            var correlationId = self.nextCorrelationId();
-            var buffer = self.protocol.write().OffsetRequest({
-                correlationId: correlationId,
-                clientId: self.options.clientId,
-                topics: topics
-            }).result;
-
-            return self.brokerConnections[leader].send(correlationId, buffer).then(function (responseBuffer) {
-                return self.protocol.read(responseBuffer).OffsetResponse().result.topics;
-            });
-        }))
-        .then(_mapTopics);
-    });
-};
-
-Client.prototype.getOffset = function (leader, topic, partition, time) {
+Client.prototype.getPartitionOffset = function (leader, topic, partition, time) {
     var request = {};
 
     request[leader] = [{
@@ -498,6 +478,26 @@ Client.prototype.getOffset = function (leader, topic, partition, time) {
             throw p.error;
         }
         return p.offset[0];
+    });
+};
+
+Client.prototype.offsetRequest = function (requests) {
+    var self = this;
+
+    return self._waitMetadata().then(function () {
+        return Promise.all(_.map(requests, function (topics, leader) {
+            var correlationId = self.nextCorrelationId();
+            var buffer = self.protocol.write().OffsetRequest({
+                correlationId: correlationId,
+                clientId: self.options.clientId,
+                topics: topics
+            }).result;
+
+            return self.brokerConnections[leader].send(correlationId, buffer).then(function (responseBuffer) {
+                return self.protocol.read(responseBuffer).OffsetResponse().result.topics;
+            });
+        }))
+        .then(_mapTopics);
     });
 };
 

--- a/lib/group_admin.js
+++ b/lib/group_admin.js
@@ -104,7 +104,7 @@ GroupAdmin.prototype._fetchHighWaterMark = function (offsetFetchRequestArgs) {
 GroupAdmin.prototype._fetchHighWaterMarkOffset = function (topicName, partition) {
     var self = this;
     return self.client.findLeader(topicName, partition).then(function (leader) {
-        return self.client.getOffset(leader, topicName, partition);
+        return self.client.getPartitionOffset(leader, topicName, partition);
     }).then(function (offset) {
         return {
             topic: topicName,

--- a/lib/group_admin.js
+++ b/lib/group_admin.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Client = require('./client');
+var Promise = require('./bluebird-configured');
 
 function GroupAdmin(options) {
     this.client = new Client(options);
@@ -35,6 +36,82 @@ GroupAdmin.prototype.listGroups = function () {
  */
 GroupAdmin.prototype.describeGroup = function (groupId) {
     return this.client.describeGroupRequest(groupId);
+};
+
+/**
+ * Provides output similar to
+ * kafka.admin.ConsumerGroupCommand --describe
+ *
+ * @param  {String} groupId
+ * @param  {Array} offsetFetchRequestArgs
+ * @return {Promise}
+ */
+GroupAdmin.prototype.fetchConsumerLag = function (groupId, offsetFetchRequestArgs) {
+    return Promise.all([
+        this.client.offsetFetchRequestV1(groupId, offsetFetchRequestArgs),
+        this._fetchHighWaterMark(offsetFetchRequestArgs)
+    ]).spread(function (offsets, highWaterMark) {
+        var i, j, res;
+        var responses = [];
+
+        // Match the returned data into a coherent response
+        for (i = 0; i < offsets.length; i++) {
+            res = {
+                topic: offsets[i].topic,
+                partition: offsets[i].partition,
+                offset: offsets[i].offset,
+                highwaterMark: null,
+                consumerLag: null
+            };
+
+            for (j = 0; j < highWaterMark.length; j++) {
+                if (
+                    offsets[i].topic === highWaterMark[j].topic
+                    && offsets[i].partition === highWaterMark[j].partition
+                ) {
+                    res.highwaterMark = highWaterMark[j].highWaterMark;
+                    if (res.offset > 0 && res.highwaterMark > 0) {
+                        res.consumerLag = res.highwaterMark - res.offset;
+                    }
+                }
+            }
+
+            responses.push(res);
+        }
+
+        return responses;
+    });
+};
+
+GroupAdmin.prototype._fetchHighWaterMark = function (offsetFetchRequestArgs) {
+    var topicName, topicPartitions, i, j;
+    var offsetRequestsPromises = [];
+
+    for (i = 0; i < offsetFetchRequestArgs.length; i++) {
+        topicName = offsetFetchRequestArgs[i].topicName;
+        topicPartitions = offsetFetchRequestArgs[i].partitions;
+
+        for (j = 0; j < topicPartitions.length; j++) {
+            offsetRequestsPromises.push(
+                this._fetchHighWaterMarkOffset(topicName, topicPartitions[j])
+            );
+        }
+    }
+
+    return Promise.all(offsetRequestsPromises);
+};
+
+GroupAdmin.prototype._fetchHighWaterMarkOffset = function (topicName, partition) {
+    var self = this;
+    return self.client.findLeader(topicName, partition).then(function (leader) {
+        return self.client.getOffset(leader, topicName, partition);
+    }).then(function (offset) {
+        return {
+            topic: topicName,
+            partition: partition,
+            highWaterMark: offset
+        };
+    });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "Oleksiy Krivoshey",
     "email": "oleksiyk@gmail.com"
   },
-  "version": "3.1.1",
+  "version": "3.1.0",
   "main": "./lib/index.js",
   "keywords": [
     "kafka"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "Oleksiy Krivoshey",
     "email": "oleksiyk@gmail.com"
   },
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "./lib/index.js",
   "keywords": [
     "kafka"

--- a/test/04.group_admin.js
+++ b/test/04.group_admin.js
@@ -43,10 +43,16 @@ describe('GroupAdmin', function () {
 
     it('should list groups', function () {
         return admin.listGroups().then(function (groups) {
+            var found = false;
+
             groups.should.be.an('array').and.have.length.gt(0);
-            groups[0].should.be.an('object');
-            groups[0].should.have.property('groupId', consumer.options.groupId);
-            groups[0].should.have.property('protocolType', 'consumer');
+            groups.forEach(function (group) {
+                if (group.groupId === consumer.options.groupId) {
+                    group.should.have.property('protocolType', 'consumer');
+                    found = true;
+                }
+            });
+            found.should.equal(true);
         });
     });
 

--- a/test/04.group_admin.js
+++ b/test/04.group_admin.js
@@ -5,16 +5,16 @@
 var Promise = require('bluebird');
 var Kafka   = require('../lib/index');
 
-var admin = new Kafka.GroupAdmin({ clientId: 'admin' });
-var consumer = new Kafka.GroupConsumer({
-    groupId: 'no-kafka-admin-test-group',
-    timeout: 1000,
-    idleTimeout: 100,
-    heartbeatTimeout: 100,
-    clientId: 'group-consumer'
-});
-
 describe('GroupAdmin', function () {
+    var admin = new Kafka.GroupAdmin({ clientId: 'admin' });
+    var consumer = new Kafka.GroupConsumer({
+        groupId: 'no-kafka-admin-test-group',
+        timeout: 1000,
+        idleTimeout: 100,
+        heartbeatTimeout: 100,
+        clientId: 'group-consumer'
+    });
+
     before(function () {
         return Promise.all([
             admin.init(),
@@ -78,6 +78,82 @@ describe('GroupAdmin', function () {
             group.members[0].memberAssignment.should.have.property('partitionAssignment').that.is.an('array');
             group.members[0].memberAssignment.partitionAssignment[0].should.have.property('topic', 'kafka-test-topic');
             group.members[0].memberAssignment.partitionAssignment[0].should.have.property('partitions').that.is.an('array', [0, 1, 2]);
+        });
+    });
+});
+
+describe('GroupAdmin', function () {
+    var admin = new Kafka.GroupAdmin({ clientId: 'admin' });
+    var consumer = new Kafka.GroupConsumer({
+        groupId: 'no-kafka-admin-test-group',
+        timeout: 1000,
+        idleTimeout: 100,
+        heartbeatTimeout: 100,
+        clientId: 'group-consumer'
+    });
+    var producer = new Kafka.Producer({
+        requiredAcks: 1,
+        clientId: 'producer'
+    });
+
+    after(function () {
+        return Promise.all([
+            admin.end(),
+            consumer.end(),
+            producer.end()
+        ]);
+    });
+
+    it('should fetch consumer lag', function () {
+        return new Promise(function (resolve) {
+            Promise.all([
+                admin.init(),
+                // Produce and consume a message in order to set
+                // the current offset for partition 0
+                consumer.init({
+                    subscriptions: ['kafka-test-topic'],
+                    metadata: 'consumer-metadata',
+                    handler: function (messageSet, topic, partition) {
+                        return Promise.each(messageSet, function (m) {
+                            // commit offset
+                            return consumer.commitOffset(
+                                {
+                                    topic: topic,
+                                    partition: partition,
+                                    offset: m.offset
+                                }
+                            );
+                        }).then(function () {
+                            // All messages consumed,
+                            // expecting lag to be 0 at this point
+                            resolve();
+                        });
+                    }
+                }),
+                producer.init()
+            ]).then(function () {
+                producer.send({
+                    topic: 'kafka-test-topic',
+                    partition: 0,
+                    message: {
+                        key: 'test-key',
+                        value: 'Hello!'
+                    }
+                });
+            });
+        }).then(function () {
+            return admin.fetchConsumerLag(consumer.options.groupId, [{
+                topicName: 'kafka-test-topic',
+                partitions: [0, 1, 2]
+            }]);
+        }).then(function (consumers) {
+            consumers.should.have.length(3, 'asked for 3 partitions, expecting 3 responses');
+            consumers[0].should.have.property('topic');
+            consumers[0].should.have.property('partition');
+            consumers[0].should.have.property('offset');
+            consumers[0].should.have.property('highwaterMark');
+            consumers[0].should.have.property('consumerLag');
+            consumers[0].consumerLag.should.be.equal(0, 'expecting no lag, all messages are consumed');
         });
     });
 });


### PR DESCRIPTION
I need to get consumer lag for monitoring purposes. Added a method that returns output similar to `bin/kafka-run-class.sh kafka.admin.ConsumerGroupCommand --describe --group <groupId>`