### PR TITLE
Encrypt communication using self-signed certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,22 @@ Or as text strings:
 KAFKA_URL=kafka://127.0.0.1:9093 KAFKA_CLIENT_CERT=`cat ./test/ssl/client.crt` KAFKA_CLIENT_CERT_KEY=`cat ./test/ssl/client.key` node producer.js
 ```
 
+Using a self signed certificate:
+
+```javascript
+Kafka.Producer({
+  connectionString: 'kafka://127.0.0.1:9093', // should match `listeners` SSL option in Kafka config
+  ssl: {
+    ca: '/path/to/my-cert.crt' // or fs.readFileSync('my-cert.crt')
+  }
+});
+```
+
+It is also possible to use `KAFKA_CLIENT_CA` environment variable to specify a self signed SSL certificate:
+
+```bash
+KAFKA_URL=kafka://127.0.0.1:9093 KAFKA_CLIENT_CA=./test/ssl/my-cert.crt node producer.js
+```
 
 ### Remapping Broker Addresses
 Sometimes the advertised listener addresses for a Kafka cluster may be incorrect from the client,

--- a/lib/client.js
+++ b/lib/client.js
@@ -96,10 +96,6 @@ Client.prototype.init = function () {
         self.options.ssl.key = process.env.KAFKA_CLIENT_CERT_KEY_STR;
     }
 
-    if (process.env.KAFKA_CLIENT_CA) {
-        self.options.ssl.ca = process.env.KAFKA_CLIENT_CA;
-    }
-
     if (self.options.ssl.cert && self.options.ssl.key) {
         if (!/^-----BEGIN/.test(self.options.ssl.cert.toString('utf8'))) {
             p = Promise.all([

--- a/lib/client.js
+++ b/lib/client.js
@@ -22,7 +22,8 @@ function Client(options) {
             key: process.env.KAFKA_CLIENT_CERT_KEY,
             // secureProtocol: 'TLSv1_method',
             rejectUnauthorized: false,
-            // ciphers: 'DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-SHA256:AES128-SHA:AES256-SHA256:AES256-SHA:RC4-SHA'
+            // ciphers: 'DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-SHA256:AES128-SHA:AES256-SHA256:AES256-SHA:RC4-SHA',
+            ca: process.env.KAFKA_CLIENT_CA
         },
         asyncCompression: true,
         brokerRedirection: false,
@@ -95,6 +96,10 @@ Client.prototype.init = function () {
         self.options.ssl.key = process.env.KAFKA_CLIENT_CERT_KEY_STR;
     }
 
+    if (process.env.KAFKA_CLIENT_CA) {
+        self.options.ssl.ca = process.env.KAFKA_CLIENT_CA;
+    }
+
     if (self.options.ssl.cert && self.options.ssl.key) {
         if (!/^-----BEGIN/.test(self.options.ssl.cert.toString('utf8'))) {
             p = Promise.all([
@@ -106,6 +111,12 @@ Client.prototype.init = function () {
                 self.options.ssl.key = key;
             });
         }
+    }
+
+    if (self.options.ssl.ca && !/^-----BEGIN CERTIFICATE-----/.test(self.options.ssl.ca.toString('utf8'))) {
+        p = readFile(self.options.ssl.ca).then(function (ca) {
+            self.options.ssl.ca = ca;
+        });
     }
 
     return p.then(function () {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -67,7 +67,7 @@ Connection.prototype.connect = function () {
                 return;
             }
 
-            if (self.options.ssl && self.options.ssl.cert && self.options.ssl.key) {
+            if (self.options.ssl && ((self.options.ssl.cert && self.options.ssl.key) || self.options.ssl.ca)) {
                 self.socket = tls.connect(self.options.port, self.options.host, self.options.ssl, onConnect);
             } else {
                 self.socket = net.connect(self.options.port, self.options.host, onConnect);

--- a/test/08.connection.js
+++ b/test/08.connection.js
@@ -139,8 +139,8 @@ describe('Connection', function () {
         before(function () {
             configuredCert = process.env.KAFKA_CLIENT_CERT;
             configuredKey = process.env.KAFKA_CLIENT_CERT_KEY;
-            process.env.KAFKA_CLIENT_CERT = null;
-            process.env.KAFKA_CLIENT_CERT_KEY = null;
+            delete process.env.KAFKA_CLIENT_CERT;
+            delete process.env.KAFKA_CLIENT_CERT_KEY;
         });
 
         after(function () {

--- a/test/08.connection.js
+++ b/test/08.connection.js
@@ -137,13 +137,15 @@ describe('Connection', function () {
         var configuredCert, configuredKey;
 
         before(function () {
-            configuredCert = process.env.KAFKA_CLIENT_CERT_STR;
-            configuredKey = process.env.KAFKA_CLIENT_CERT_KEY_STR;
+            configuredCert = process.env.KAFKA_CLIENT_CERT;
+            configuredKey = process.env.KAFKA_CLIENT_CERT_KEY;
+            process.env.KAFKA_CLIENT_CERT = null;
+            process.env.KAFKA_CLIENT_CERT_KEY = null;
         });
 
         after(function () {
-            process.env.KAFKA_CLIENT_CERT_STR = configuredCert;
-            process.env.KAFKA_CLIENT_CERT_KEY_STR = configuredKey;
+            process.env.KAFKA_CLIENT_CERT = configuredCert;
+            process.env.KAFKA_CLIENT_CERT_KEY = configuredKey;
         });
 
         it('should load from file', function () {

--- a/test/08.connection.js
+++ b/test/08.connection.js
@@ -2,6 +2,8 @@
 
 /* global describe, it, before, sinon, after  */
 
+var path = require('path');
+var fs = require('fs');
 var Promise = require('bluebird');
 var crc32   = require('buffer-crc32');
 var Kafka   = require('../lib/index');
@@ -128,6 +130,39 @@ describe('Connection', function () {
             p.client.initialBrokers[0].server().should.be.eql('127.0.0.1:9092');
             p.client.initialBrokers[1].server().should.be.eql('127.0.0.1:9092');
             p.client.initialBrokers[2].server().should.be.eql('127.0.0.1:9092');
+        });
+    });
+
+    describe('when configuring SSL CA', function () {
+        var configuredCert, configuredKey;
+
+        before(function () {
+            configuredCert = process.env.KAFKA_CLIENT_CERT_STR;
+            configuredKey = process.env.KAFKA_CLIENT_CERT_KEY_STR;
+        });
+
+        after(function () {
+            process.env.KAFKA_CLIENT_CERT_STR = configuredCert;
+            process.env.KAFKA_CLIENT_CERT_KEY_STR = configuredKey;
+        });
+
+        it('should load from file', function () {
+            var caPath = path.join(__dirname, './ssl/client.crt');
+            var p = new Kafka.Producer({ connectionString: 'kafka://127.0.0.1:9093', ssl: { ca: caPath } });
+
+            return p.init().then(function () {
+                p.client.options.ssl.ca.should.be.eql(fs.readFileSync(caPath));
+            });
+        });
+
+        it('should load from string', function () {
+            var caPath = path.join(__dirname, './ssl/client.crt');
+            var caContent = fs.readFileSync(caPath);
+            var p = new Kafka.Producer({ connectionString: 'kafka://127.0.0.1:9093', ssl: { ca: caContent } });
+
+            return p.init().then(function () {
+                p.client.options.ssl.ca.should.be.eql(caContent);
+            });
         });
     });
 });


### PR DESCRIPTION
This PR fixes issue #168 

It adds the `ssl.ca` option:

```javascript
Kafka.Producer({
  connectionString: 'kafka://<something>'
  ssl: {
    ca: '/path/to/my-cert.crt' // or fs.readFileSync('my-cert.crt')
  }
});
```

It also accepts `process.env.KAFKA_CLIENT_CA`