### PR TITLE
Test null/empty bytes type

### DIFF
--- a/lib/protocol/common.js
+++ b/lib/protocol/common.js
@@ -17,7 +17,7 @@ var _        = require('lodash');
 Protocol.define('bytes', {
     read: function () {
         this.Int32BE('length');
-        if (this.context.length <= 0) {
+        if (this.context.length < 0) {
             return null;
         }
         this.raw('value', this.context.length);
@@ -41,7 +41,7 @@ Protocol.define('bytes', {
 Protocol.define('string', {
     read: function () {
         this.Int16BE('length');
-        if (this.context.length <= 0) {
+        if (this.context.length < 0) {
             return null;
         }
         this.raw('value', this.context.length);
@@ -63,7 +63,9 @@ Protocol.define('string', {
 Protocol.define('array', {
     read: function (fn) {
         this.Int32BE('length');
-        if (this.context.length <= 0) {
+        if (this.context.length < 0) {
+            return null;
+        } else if (this.context.length === 0) {
             return [];
         }
         this.loop('items', fn, this.context.length);


### PR DESCRIPTION
Fix parsing (reading) of null/empty bytes/string/array types. Tested with:

```bash
# key = null
echo 'hello' | /usr/local/sirv/src/kafka_2.11-0.9.0.1/bin/kafka-console-producer.sh --topic kafka-test-topic --broker-list 127.0.0.1:9092

# key = <Buffer > (empty)
echo ':world' | /usr/local/sirv/src/kafka_2.11-0.9.0.1/bin/kafka-console-producer.sh --topic kafka-test-topic --broker-list 127.0.0.1:9092 --property "parse.key=true" --property "key.separator=:"
```