### PR TITLE
Add possibility to specify socket timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ return producer.init().then(function(){
   * `size` - group messages together into single batch until their total size exceeds this value, defaults to 16384 bytes. Set to 0 to disable batching.
   * `maxWait` - send grouped messages after this amount of milliseconds expire even if their total size doesn't exceed `batch.size` yet, defaults to 10ms. Set to 0 to disable batching.
 * `asyncCompression` - boolean, use asynchronouse compression instead of synchronous, defaults to `false`
+* `connectionTimeout` - timeout for establishing connection to Kafka in milliseconds, defaults to 3000ms
+* `socketTimeout` - timeout for Kafka connection socket in milliseconds, defaults to 0 (disabled)
 
 ## SimpleConsumer
 
@@ -299,6 +301,8 @@ consumer.fetchOffset([
 * `recoveryOffset` - recovery position (time) which will used to recover subscription in case of OffsetOutOfRange error, defaults to Kafka.LATEST_OFFSET
 * `asyncCompression` - boolean, use asynchronouse decompression instead of synchronous, defaults to `false`
 * `handlerConcurrency` - specify concurrency level for the consumer handler function, defaults to 10
+* `connectionTimeout` - timeout for establishing connection to Kafka in milliseconds, defaults to 3000ms
+* `socketTimeout` - timeout for Kafka connection socket in milliseconds, defaults to 0 (disabled)
 
 ## GroupConsumer (new unified consumer API)
 
@@ -384,6 +388,8 @@ You can also write your own assignment strategy by inheriting from Kafka.Default
 * `recoveryOffset` - recovery position (time) which will used to recover subscription in case of OffsetOutOfRange error, defaults to Kafka.LATEST_OFFSET
 * `asyncCompression` - boolean, use asynchronouse decompression instead of synchronous, defaults to `false`
 * `handlerConcurrency` - specify concurrency level for the consumer handler function, defaults to 10
+* `connectionTimeout` - timeout for establishing connection to Kafka in milliseconds, defaults to 3000ms
+* `socketTimeout` - timeout for Kafka connection socket in milliseconds, defaults to 0 (disabled)
 
 ## GroupAdmin (consumer groups API)
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -134,7 +134,9 @@ Client.prototype._createConnection = function (host, port) {
         return new Connection({
             host: host,
             port: port,
-            ssl: this.options.ssl
+            ssl: this.options.ssl,
+            connectionTimeout: this.options.connectionTimeout,
+            socketTimeout: this.options.socketTimeout,
         });
     }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -11,6 +11,7 @@ function Connection(options) {
         port: 9092,
         host: '127.0.0.1',
         connectionTimeout: 3000,
+        socketTimeout: 0,
         initialBufferSize: 256 * 1024,
         ssl: {}
     });
@@ -73,6 +74,11 @@ Connection.prototype.connect = function () {
                 self.socket = net.connect(self.options.port, self.options.host, onConnect);
             }
 
+            self.socket.setTimeout(self.options.socketTimeout);
+
+            self.socket.on('timeout', function () {
+                self._disconnect(new NoKafkaConnectionError(self.server(), 'Socket timeout'));
+            });
             self.socket.on('end', function () {
                 self._disconnect(new NoKafkaConnectionError(self.server(), 'Kafka server has closed connection'));
             });

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -27,6 +27,7 @@ declare module "connection" {
         port?: number;
         host?: string;
         connectionTimeout?: number;
+        socketTimeout?: number;
         initialBufferSize?: number;
         ssl?: {
             cert: string;

--- a/types/group_consumer.d.ts
+++ b/types/group_consumer.d.ts
@@ -121,6 +121,18 @@ declare module "group_consumer" {
          * defaults to 10
          */
         handlerConcurrency?: number;
+        /**
+         * connectionTimeout - timeout for establishing connection to Kafka in milliseconds
+         * 
+         * defaults to 3000ms
+         */
+        connectionTimeout?: number
+        /**
+         * socketTimeout - timeout for Kafka connection socket in milliseconds
+         * 
+         * defaults to 0 (disabled)
+         */
+        socketTimeout?: number
 
         brokerRedirection?: Kafka.BrokerRedirectionFunction | Kafka.BrokerRedirectionMap;
 

--- a/types/producer.d.ts
+++ b/types/producer.d.ts
@@ -160,6 +160,18 @@ declare module "producer" {
          * Should match `listeners` SSL option in Kafka config
          */
         ssl?: tls.ConnectionOptions;
+        /**
+         * connectionTimeout - timeout for establishing connection to Kafka in milliseconds
+         * 
+         * defaults to 3000ms
+         */
+        connectionTimeout?: number
+        /**
+         * socketTimeout - timeout for Kafka connection socket in milliseconds
+         * 
+         * defaults to 0 (disabled)
+         */
+        socketTimeout?: number
 
         brokerRedirection?: Kafka.BrokerRedirectionFunction | Kafka.BrokerRedirectionMap;
 

--- a/types/simple_consumer.d.ts
+++ b/types/simple_consumer.d.ts
@@ -97,6 +97,18 @@ declare module "simple_consumer" {
          * default: 10
          */
         handlerConcurrency?: number;
+        /**
+         * connectionTimeout - timeout for establishing connection to Kafka in milliseconds
+         * 
+         * defaults to 3000ms
+         */
+        connectionTimeout?: number
+        /**
+         * socketTimeout - timeout for Kafka connection socket in milliseconds
+         * 
+         * defaults to 0 (disabled)
+         */
+        socketTimeout?: number
 
         brokerRedirection?: Kafka.BrokerRedirectionFunction | Kafka.BrokerRedirectionMap;
 


### PR DESCRIPTION
This PR adds socket timeout handler for kafka connection.

We faced with an issue when our service actively consumes data from Kafka in multiple node processes:
The client "writes" to socket but does not get any event back. As result, promise is not resolved/rejected and we get a pending connection which stops consuming. 
I was not able to identify the  exact root cause of the issue but I think it makes sense to set timeout for socket and add corresponding handler.  
I put 30s as default socket timeout value. Let me know if you think it should be adjusted. 