### PR TITLE
fixed getting stuck when GroupConsumer#_joinGroup is failing.

### DIFF
--- a/lib/group_consumer.js
+++ b/lib/group_consumer.js
@@ -190,13 +190,9 @@ GroupConsumer.prototype._fullRejoin = function () {
         return self.client.updateGroupCoordinator(self.options.groupId).then(function () {
             return self._joinGroup().then(function () { // join group
                 return self._rejoin(); // rejoin and sync with received memberId
-            })
-            .catch(Promise.AggregateError, function (err) {
-                self.client.error('Full rejoin attempt failed here:', err[0]);
-                throw err[0];
             });
         })
-        .catch(errors.NoKafkaConnectionError, { code: 'UnknownMemberId' }, { code: 'NotCoordinatorForGroup' }, function (err) {
+        .catch(function (err) {
             self.client.error('Full rejoin attempt failed:', err);
             return Promise.delay(1000).then(_tryFullRejoin);
         });

--- a/lib/group_consumer.js
+++ b/lib/group_consumer.js
@@ -185,10 +185,15 @@ GroupConsumer.prototype._fullRejoin = function () {
     var self = this;
 
     return (function _tryFullRejoin() {
+        self.client.debug('Trying full rejoin');
         self.memberId = null;
         return self.client.updateGroupCoordinator(self.options.groupId).then(function () {
             return self._joinGroup().then(function () { // join group
                 return self._rejoin(); // rejoin and sync with received memberId
+            })
+            .catch(Promise.AggregateError, function (err) {
+                self.client.error('Full rejoin attempt failed here:', err[0]);
+                throw err[0];
             });
         })
         .catch(errors.NoKafkaConnectionError, { code: 'UnknownMemberId' }, { code: 'NotCoordinatorForGroup' }, function (err) {
@@ -197,6 +202,7 @@ GroupConsumer.prototype._fullRejoin = function () {
         });
     }())
     .tap(function () {
+        self.client.debug('Re-starting heartbeats');
         self._heartbeatPromise = self._heartbeat(); // start sending heartbeats
         return null;
     });

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "no-kafka",
+  "name": "no-kafka-fork-ibm",
   "description": "Apache Kafka 0.9 client for Node.JS",
   "homepage": "http://github.com/oleksiyk/kafka",
   "author": {
     "name": "Oleksiy Krivoshey",
     "email": "oleksiyk@gmail.com"
   },
-  "version": "3.2.2",
+  "version": "3.2.3",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",
   "keywords": [


### PR DESCRIPTION
This PR fixes a problem we have seen in no-kafka that would cause the consumer to hang forever and not attempt to rejoin. This would occur intermittently if a messagehub outage occurred.

This happens when the kafka server (in our case messagehub) is down. when you try to rejoin you will be in a reconnect loop and when the rejoins are failing you get an AggregateError. This contains errors.NoKafkaConnectionError for each of the kafka brokers in the cluster so catching that on the _joinGroup() call and then just re-throwing the first on in the Aggregate correctly puts us back into the `catch(errors.NoKafkaConnectionError, { code: 'UnknownMemberId' }, { code: 'NotCoordinatorForGroup' }` lower down that schedules another delayed attempt at a full rejoin.

We reproduced this problem by rolling restating a messagehub cluster and have confirmed this fixes the issue we where seeing.