### PR TITLE
Export all Typescript types

### DIFF
--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -51,11 +51,11 @@ declare module "client" {
         listGroupsRequest(): Promise<any>;
         describeGroupRequest(groupId: any): Promise<any>;
 
-        log(...any: []): void;
-        debug(...any: []): void;
-        error(...any: []): void;
-        warn(...any: []): void;
-        trace(...any: []): void;
+        log(...args: any[]): void;
+        debug(...args: any[]): void;
+        error(...args: any[]): void;
+        warn(...args: any[]): void;
+        trace(...args: any[]): void;
     }
 
     export interface ClientOptions {

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -24,6 +24,8 @@ declare module "client" {
      * @class Client
      */
     export class Client {
+        options: ClientOptions;
+        finished: boolean;
         constructor(options?: ClientOptions);
         init(): Promise<Client>;
         end(): void;

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -48,6 +48,12 @@ declare module "client" {
 
         listGroupsRequest(): Promise<any>;
         describeGroupRequest(groupId: any): Promise<any>;
+
+        log(...any: []): void;
+        debug(...any: []): void;
+        error(...any: []): void;
+        warn(...any: []): void;
+        trace(...any: []): void;
     }
 
     export interface ClientOptions {

--- a/types/group_consumer.d.ts
+++ b/types/group_consumer.d.ts
@@ -158,6 +158,6 @@ declare module "group_consumer" {
 
 
     export interface DataHandler {
-        (messageSet: string[], topic: string, partition: number): Promise<any>;
+        (messageSet: Kafka.Message[], topic: string, partition: number): Promise<any>;
     }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,11 +16,13 @@
 declare module "no-kafka" {
 
     export * from "kafka";
-    export { Producer, Result } from "producer";
-    export { SimpleConsumer } from "simple_consumer";
-    export { GroupConsumer } from "group_consumer";
+    export * from "client";
 
-    export { GroupAdmin } from "group_admin";
+    export * from "producer";
+    export * from "simple_consumer";
+    export * from "group_consumer";
+
+    export * from "group_admin";
 
     export { DefaultPartitioner } from "assignment/partitioners/default";
     export { HashCRC32Partitioner } from "assignment/partitioners/hash_crc32";

--- a/types/producer.d.ts
+++ b/types/producer.d.ts
@@ -273,7 +273,7 @@ declare module "producer" {
          * codec - compression codec, one of 
          *   Kafka.COMPRESSION_NONE, Kafka.COMPRESSION_SNAPPY, Kafka.COMPRESSION_GZIP
          */
-        codec: number; // Kafka.COMPRESSION_NONE | Kafka.COMPRESSION_SNAPPY | Kafka.COMPRESSION_GZIP;
+        codec?: number; // Kafka.COMPRESSION_NONE | Kafka.COMPRESSION_SNAPPY | Kafka.COMPRESSION_GZIP;
         /**
          * batch - control batching (grouping) of requests
          */


### PR DESCRIPTION
In order to use the types properly with Typescript they need to be exported. The original type declaration exports some but not all of the types. This PR exports all of the types and fixes a couple of missing/incorrect types.