### PR TITLE
Fix types to export as modules rather than global declarations

### DIFF
--- a/types/assignment/index.d.ts
+++ b/types/assignment/index.d.ts
@@ -1,0 +1,2 @@
+export * from './partitioners';
+export * from './strategies';

--- a/types/assignment/partitioners/default.d.ts
+++ b/types/assignment/partitioners/default.d.ts
@@ -1,15 +1,11 @@
-
-declare module "assignment/partitioners/default" {
-    export class DefaultPartitioner {
-        constructor();
-        /**
-         * The partition method receives 3 arguments: 
-         * * the topic name, 
-         * * an array with topic partitions, and 
-         * * the message (useful to partition by key, etc.). 
-         * The call to partition can be sync or async (return a Promise).
-         */
-        partition(topic: string, partitions: number[], message: string): Promise<number>;
-
-    }
+export class DefaultPartitioner {
+    constructor();
+    /**
+      * The partition method receives 3 arguments: 
+      * * the topic name, 
+      * * an array with topic partitions, and 
+      * * the message (useful to partition by key, etc.). 
+      * The call to partition can be sync or async (return a Promise).
+      */
+    partition(topic: string, partitions: number[], message: string): Promise<number>;
 }

--- a/types/assignment/partitioners/hash_crc32.d.ts
+++ b/types/assignment/partitioners/hash_crc32.d.ts
@@ -1,16 +1,12 @@
+export class HashCRC32Partitioner {
+    constructor();
+    /**
+      * The partition method receives 3 arguments: 
+      * * the topic name, 
+      * * an array with topic partitions, and 
+      * * the message (useful to partition by key, etc.). 
+      * The call to partition can be sync or async (return a Promise).
+      */
+    partition(topic: string, partitions: number[], message: string): Promise<number>;
 
-
-declare module "assignment/partitioners/hash_crc32" {
-    export class HashCRC32Partitioner {
-        constructor();
-        /**
-         * The partition method receives 3 arguments: 
-         * * the topic name, 
-         * * an array with topic partitions, and 
-         * * the message (useful to partition by key, etc.). 
-         * The call to partition can be sync or async (return a Promise).
-         */
-        partition(topic: string, partitions: number[], message: string): Promise<number>;
-
-    }
 }

--- a/types/assignment/partitioners/index.d.ts
+++ b/types/assignment/partitioners/index.d.ts
@@ -1,0 +1,1 @@
+export * from './hash_crc32';

--- a/types/assignment/strategies/consistent.d.ts
+++ b/types/assignment/strategies/consistent.d.ts
@@ -1,13 +1,8 @@
+import * as Kafka from "../../kafka";
 
-declare module "assignment/strategies/consistent" {
-
-    import * as Kafka from "kafka";
-    
-    /** 
-    * ConsistentAssignmentStrategy which is based on a consistent hash ring and so provides consistent assignment across consumers in a group based on supplied metadata.id and metadata.weight options.
-    */
-    export class ConsistentAssignmentStrategy implements Kafka.AbstractAssignmentStrategy {
-        constructor();
-    }
-
+/** 
+* ConsistentAssignmentStrategy which is based on a consistent hash ring and so provides consistent assignment across consumers in a group based on supplied metadata.id and metadata.weight options.
+*/
+export class ConsistentAssignmentStrategy implements Kafka.AbstractAssignmentStrategy {
+    constructor();
 }

--- a/types/assignment/strategies/default.d.ts
+++ b/types/assignment/strategies/default.d.ts
@@ -1,15 +1,10 @@
-
-
-declare module "assignment/strategies/default" {
-    import * as Kafka from "kafka";
-    /**
-     * simple round robin assignment strategy (default).
-     * 
-     * @export
-     * @class DefaultAssignmentStrategy
-     */
-    export class DefaultAssignmentStrategy implements Kafka.AbstractAssignmentStrategy {
-        constructor();
-    }
-
+import * as Kafka from "../../kafka";
+/**
+  * simple round robin assignment strategy (default).
+  * 
+  * @export
+  * @class DefaultAssignmentStrategy
+  */
+export class DefaultAssignmentStrategy implements Kafka.AbstractAssignmentStrategy {
+    constructor();
 }

--- a/types/assignment/strategies/index.d.ts
+++ b/types/assignment/strategies/index.d.ts
@@ -1,0 +1,3 @@
+export * from './consistent';
+export * from './default';
+export * from './weighted_round_robin';

--- a/types/assignment/strategies/weighted_round_robin.d.ts
+++ b/types/assignment/strategies/weighted_round_robin.d.ts
@@ -1,13 +1,8 @@
+import * as Kafka from "../../kafka";
 
-
-declare module "assignment/strategies/weighted_round_robin" {
-    import * as Kafka from "kafka";
-
-    /** 
-    * WeightedRoundRobinAssignmentStrategy weighted round robin assignment (based on wrr-pool).
-    */
-    export class WeightedRoundRobinAssignmentStrategy implements Kafka.AbstractAssignmentStrategy {
-        constructor();
-    }
-
+/** 
+* WeightedRoundRobinAssignmentStrategy weighted round robin assignment (based on wrr-pool).
+*/
+export class WeightedRoundRobinAssignmentStrategy implements Kafka.AbstractAssignmentStrategy {
+    constructor();
 }

--- a/types/base_consumer.d.ts
+++ b/types/base_consumer.d.ts
@@ -1,35 +1,30 @@
+import * as Kafka from "./kafka";
 
+export class BaseConsumer {
+    constructor(options: BaseConsumerOptions);
 
+    init(): Promise<void>;
 
-declare module "base_consumer" {
-    import * as Kafka from "kafka";
+    subscribe(topic: string, offset: number | number[],
+        options: BaseConsumerOptions,
+        handler: DataHandler): Promise<void>;
 
-    export class BaseConsumer {
-        constructor(options: BaseConsumerOptions);
+    unsubscribe(topic: string, partitions?: number | number[]): Promise<number[]>;
+    offset(topic: string, partition?: number): Promise<number>;
 
-        init(): Promise<void>;
-
-        subscribe(topic: string, offset: number | number[],
-            options: BaseConsumerOptions,
-            handler: DataHandler): Promise<void>;
-
-        unsubscribe(topic: string, partitions?: number | number[]): Promise<number[]>;
-        offset(topic: string, partition?: number): Promise<number>;
-
-        end(): Promise<void>;
-
-    }
-
-    export interface BaseConsumerOptions {
-        offset?: number;
-        maxBytes?: number;
-        time?: Kafka.OFFSET
-    }
-
-    export interface DataHandler {
-        (messageSet: Kafka.Message[],
-            topic: string,
-            partition?: number): Promise<any>;
-    }
+    end(): Promise<void>;
 
 }
+
+export interface BaseConsumerOptions {
+    offset?: number;
+    maxBytes?: number;
+    time?: Kafka.OFFSET
+}
+
+export interface DataHandler {
+    (messageSet: Kafka.Message[],
+        topic: string,
+        partition?: number): Promise<any>;
+}
+

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,3 +1,4 @@
+import * as tls from 'tls';
 /**
   * Something to hold the socket endpoint.
   * 

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -51,11 +51,11 @@ declare module "client" {
         listGroupsRequest(): Promise<any>;
         describeGroupRequest(groupId: any): Promise<any>;
 
-        log(...any: []): void;
-        debug(...any: []): void;
-        error(...any: []): void;
-        warn(...any: []): void;
-        trace(...any: []): void;
+        log(...args: any[]): void;
+        debug(...args: any[]): void;
+        error(...args: any[]): void;
+        warn(...args: any[]): void;
+        trace(...args: any[]): void;
     }
 
     export interface ClientOptions {

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,82 +1,76 @@
+/**
+  * Something to hold the socket endpoint.
+  * 
+  * @export
+  * @class Client
+  */
+export interface EndPoint {
+    host: string;
+    port: number;
+}
 
+export interface UpdateMetadata {
+    isPending(): boolean;
+}
+/**
+  * 
+  * 
+  * @export
+  * @class Client
+  */
+export class Client {
+    options: ClientOptions;
+    finished: boolean;
+    constructor(options?: ClientOptions);
+    init(): Promise<Client>;
+    end(): void;
+    parseHostString(hostString: string): Promise<any[]>;
+    checkBrokerRedirect(host: string, port: number): Promise<EndPoint>;
+    nextCorrelationId(): number;
+    updateMetadata(): UpdateMetadata;
+    metadataRequest(topicNames: string[]): Promise<any>;
+    getTopicPartitions(topic: string): Promise<any>;
+    findLeader(topic: string, partition: number, notfoundOk: boolean): Promise<number>;
+    leaderServer(leader: string): Promise<any>;
+    produceRequest(requests: string[], codec: string): Promise<any>;
+    fetchRequest(requests: string[]): Promise<any>;
+    getPartitionOffset(leader: string, topic: string, partition: number, time: number): Promise<any>;
+    offsetRequest(requests: string[]): Promise<any>;
+    updateGroupCoordinator(groupid: string): Promise<any>;
+    joinConsumerGroupRequest(groupid: string, memberid: any, sessionTimeout: number, strategies: any[]): Promise<any>;
+    heartbeatRequest(groupId: any, memberId: any, generationId: any): Promise<any>;
+    syncConsumerGroupRequest(groupId: any, memberId: any, generationId: any, groupAssignment: any): Promise<any>;
+    leaveGroupRequest(groupId: any, memberId: any): Promise<any>;
+    offsetCommitRequestV2(groupId: any, memberId: any, generationId: any, requests: any): Promise<any>;
 
+    listGroupsRequest(): Promise<any>;
+    describeGroupRequest(groupId: any): Promise<any>;
 
-declare module "client" {
+    log(...args: any[]): void;
+    debug(...args: any[]): void;
+    error(...args: any[]): void;
+    warn(...args: any[]): void;
+    trace(...args: any[]): void;
+}
 
-    /**
-     * Something to hold the socket endpoint.
-     * 
-     * @export
-     * @class Client
-     */
-    export interface EndPoint {
-        host: string;
-        port: number;
+export interface ClientOptions {
+    clientId?: string;
+    connectionString?: string;
+    ssl?: {
+        cert: string;
+        key: string;
+        rejectUnauthorized?: boolean;
     }
-
-    export interface UpdateMetadata {
-        isPending(): boolean;
+    asyncCompression?: boolean;
+    brokerRedirection?: boolean;
+    reconnectionDelay?: {
+        max?: number;
+        min?: number;
     }
-    /**
-     * 
-     * 
-     * @export
-     * @class Client
-     */
-    export class Client {
-        options: ClientOptions;
-        finished: boolean;
-        constructor(options?: ClientOptions);
-        init(): Promise<Client>;
-        end(): void;
-        parseHostString(hostString: string): Promise<any[]>;
-        checkBrokerRedirect(host: string, port: number): Promise<EndPoint>;
-        nextCorrelationId(): number;
-        updateMetadata(): UpdateMetadata;
-        metadataRequest(topicNames: string[]): Promise<any>;
-        getTopicPartitions(topic: string): Promise<any>;
-        findLeader(topic: string, partition: number, notfoundOk: boolean): Promise<number>;
-        leaderServer(leader: string): Promise<any>;
-        produceRequest(requests: string[], codec: string): Promise<any>;
-        fetchRequest(requests: string[]): Promise<any>;
-        getPartitionOffset(leader: string, topic: string, partition: number, time: number): Promise<any>;
-        offsetRequest(requests: string[]): Promise<any>;
-        updateGroupCoordinator(groupid: string): Promise<any>;
-        joinConsumerGroupRequest(groupid: string, memberid: any, sessionTimeout: number, strategies: any[]): Promise<any>;
-        heartbeatRequest(groupId: any, memberId: any, generationId: any): Promise<any>;
-        syncConsumerGroupRequest(groupId: any, memberId: any, generationId: any, groupAssignment: any): Promise<any>;
-        leaveGroupRequest(groupId: any, memberId: any): Promise<any>;
-        offsetCommitRequestV2(groupId: any, memberId: any, generationId: any, requests: any): Promise<any>;
-
-        listGroupsRequest(): Promise<any>;
-        describeGroupRequest(groupId: any): Promise<any>;
-
-        log(...args: any[]): void;
-        debug(...args: any[]): void;
-        error(...args: any[]): void;
-        warn(...args: any[]): void;
-        trace(...args: any[]): void;
-    }
-
-    export interface ClientOptions {
-        clientId?: string;
-        connectionString?: string;
-        ssl?: {
-            cert: string;
-            key: string;
-            rejectUnauthorized?: boolean;
-        }
-        asyncCompression?: boolean;
-        brokerRedirection?: boolean;
-        reconnectionDelay?: {
-            max?: number;
-            min?: number;
-        }
-        logger?: {
-            logLevel?: number;
-            logstash?: {
-                enabled?: boolean;
-            }
+    logger?: {
+        logLevel?: number;
+        logstash?: {
+            enabled?: boolean;
         }
     }
 }

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -24,6 +24,8 @@ declare module "client" {
      * @class Client
      */
     export class Client {
+        options: ClientOptions;
+        finished: boolean;
         constructor(options?: ClientOptions);
         init(): Promise<Client>;
         end(): void;

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -48,6 +48,12 @@ declare module "client" {
 
         listGroupsRequest(): Promise<any>;
         describeGroupRequest(groupId: any): Promise<any>;
+
+        log(...any: []): void;
+        debug(...any: []): void;
+        error(...any: []): void;
+        warn(...any: []): void;
+        trace(...any: []): void;
     }
 
     export interface ClientOptions {

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -1,37 +1,33 @@
+/**
+  * no-kafka will connect to the hosts specified in 
+  * connectionString constructor option unless it is omitted.
+  * In this case it will use KAFKA_URL environment
+  * variable or fallback to default kafka://127.0.0.1:9092.
+  * For better availability always specify several initial brokers:
+  * 10.0.1.1:9092,10.0.1.2:9092,10.0.1.3:9092.
+  * The / prefix is optional.
+  * 
+  * @export
+  * @class Connection
+  */
+export class Connection {
+    constructor(options: Options);
+    equal(host: string, port: number): boolean;
+    server(): string;
+    connect(): Promise<any>;
+    close(): void;
 
+    send(correlationId: any, data: any, noresponse: any): Promise<any>;
 
-declare module "connection" {
-    /**
-     * no-kafka will connect to the hosts specified in 
-     * connectionString constructor option unless it is omitted.
-     * In this case it will use KAFKA_URL environment
-     * variable or fallback to default kafka://127.0.0.1:9092.
-     * For better availability always specify several initial brokers:
-     * 10.0.1.1:9092,10.0.1.2:9092,10.0.1.3:9092.
-     * The / prefix is optional.
-     * 
-     * @export
-     * @class Connection
-     */
-    export class Connection {
-        constructor(options: Options);
-        equal(host: string, port: number): boolean;
-        server(): string;
-        connect(): Promise<any>;
-        close(): void;
-
-        send(correlationId: any, data: any, noresponse: any): Promise<any>;
-
-    }
-    export interface Options {
-        port?: number;
-        host?: string;
-        connectionTimeout?: number;
-        socketTimeout?: number;
-        initialBufferSize?: number;
-        ssl?: {
-            cert: string;
-            key: string;
-        }
+}
+export interface Options {
+    port?: number;
+    host?: string;
+    connectionTimeout?: number;
+    socketTimeout?: number;
+    initialBufferSize?: number;
+    ssl?: {
+        cert: string;
+        key: string;
     }
 }

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -1,36 +1,30 @@
+export class KafkaErrorAbstract {
+    name: string;
+    code: any;
+    message: string;
+
+}
+export class KafkaError extends KafkaErrorAbstract {
+    constructor(code: any, message: string);
+
+    toJSON(): KafkaErrorAbstract;
+    toString(): string;
 
 
-declare module "errors" {
+}
+export function byCode(code: any): null | KafkaError;
+export function byName(name: string): null | KafkaError;
 
-    export class KafkaErrorAbstract {
-        name: string;
-        code: any;
-        message: string;
+export class NoKafkaConnectionErrorAbstract {
+    name: string;
+    server: any;
+    message: string;
 
-    }
-    export class KafkaError extends KafkaErrorAbstract {
-        constructor(code: any, message: string);
+}
+export class NoKafkaConnectionError extends NoKafkaConnectionErrorAbstract {
+    constructor(server: any, message: string);
 
-        toJSON(): KafkaErrorAbstract;
-        toString(): string;
-
-
-    }
-    export function byCode(code: any): null | KafkaError;
-    export function byName(name: string): null | KafkaError;
-
-    export class NoKafkaConnectionErrorAbstract {
-        name: string;
-        server: any;
-        message: string;
-
-    }
-    export class NoKafkaConnectionError extends NoKafkaConnectionErrorAbstract {
-        constructor(server: any, message: string);
-
-        toJSON(): NoKafkaConnectionErrorAbstract;
-        toString(): string;
-
-    }
+    toJSON(): NoKafkaConnectionErrorAbstract;
+    toString(): string;
 
 }

--- a/types/group_admin.d.ts
+++ b/types/group_admin.d.ts
@@ -1,74 +1,69 @@
+import { Client } from "./client";
 
+export class GroupAdmin {
+    constructor();
 
-declare module "group_admin" {
+    /**
+      * list existing consumer groups
+      */
+    listGroups(): Group[];
+    /**
+      * describeGroup - describe existing group by its id
+      */
+    describeGroup(groupId: string): GroupDescription;
+    /**
+      * fetchConsumerLag - fetches consumer lag for topics/partitions
+      */
+    fetchConsumerLag(groupId: string, options: FetchOptions): ConsumerLag[];
 
-    import { Client } from "client";
+}
 
-    export class GroupAdmin {
-        constructor();
+interface Group {
+    groupId?: string;
+    protocolType?: string;
+}
 
-        /**
-         * list existing consumer groups
-         */
-        listGroups(): Group[];
-        /**
-         * describeGroup - describe existing group by its id
-         */
-        describeGroup(groupId: string): GroupDescription;
-        /**
-         * fetchConsumerLag - fetches consumer lag for topics/partitions
-         */
-        fetchConsumerLag(groupId: string, options: FetchOptions): ConsumerLag[];
+interface GroupDescription {
+    error?: null | any;
+    groupId?: string;
+    state?: string; // Stable
+    protocolType?: string; // consumer
+    members?: MemberDescription[];
 
-    }
+}
 
-    interface Group {
-        groupId?: string;
-        protocolType?: string;
-    }
-
-    interface GroupDescription {
-        error?: null | any;
-        groupId?: string;
-        state?: string; // Stable
-        protocolType?: string; // consumer
-        members?: MemberDescription[];
-
-    }
-
-    interface MemberDescription {
-        memberId: string;
-        clientId: string;
-        clientHost: string;
+interface MemberDescription {
+    memberId: string;
+    clientId: string;
+    clientHost: string;
+    version: number;
+    subscriptions: string[];
+    metadata: any;
+    memberAssignment: {
+        _blength: number;
         version: number;
-        subscriptions: string[];
-        metadata: any;
-        memberAssignment: {
-            _blength: number;
-            version: number;
-            partitionAssignment: PartitionAssignment[];
-            metadata: null | any;
-        }
+        partitionAssignment: PartitionAssignment[];
+        metadata: null | any;
     }
-    export interface PartitionAssignment {
-        topic?: string;
-        partitions?: number[];
-    }
+}
+export interface PartitionAssignment {
+    topic?: string;
+    partitions?: number[];
+}
 
-    export interface FetchOptions {
-        topicName?: string;
-        partitions?: number[];
-    }
+export interface FetchOptions {
+    topicName?: string;
+    partitions?: number[];
+}
 
 /**
- * Note that group consumer has to commit offsets first, in order for consumerLag to be available. 
- * Otherwise the offset will be set to -1.
- */
-    export interface ConsumerLag {
-        topic: string;
-        partition: number;
-        offset: number;
-        highwaterMark: number;
-        consumerLag: number | null;
-    }
+* Note that group consumer has to commit offsets first, in order for consumerLag to be available. 
+* Otherwise the offset will be set to -1.
+*/
+export interface ConsumerLag {
+    topic: string;
+    partition: number;
+    offset: number;
+    highwaterMark: number;
+    consumerLag: number | null;
 }

--- a/types/group_consumer.d.ts
+++ b/types/group_consumer.d.ts
@@ -158,6 +158,6 @@ declare module "group_consumer" {
 
 
     export interface DataHandler {
-        (messageSet: string[], topic: string, partition: number): Promise<any>;
+        (messageSet: Kafka.Message[], topic: string, partition: number): Promise<any>;
     }
 }

--- a/types/group_consumer.d.ts
+++ b/types/group_consumer.d.ts
@@ -1,163 +1,151 @@
+import * as Kafka from "./kafka";
+import { BaseConsumer } from "./base_consumer";
 
+export class GroupConsumer extends BaseConsumer {
+    constructor(options?: GroupConsumerOptions);
 
+    commitOffset(commits: Kafka.Commit | Kafka.Commit[]): Promise<any>;
+    fetchOffset(commits: Kafka.Commit | Kafka.Commit[]): Promise<number[]>;
 
-declare module "group_consumer" {
-    import * as Kafka from "kafka";
-    import { BaseConsumer } from "base_consumer";
-    
-    export class GroupConsumer extends BaseConsumer {
-        constructor(options?: GroupConsumerOptions);
+    init(strategies?: Strategy | Strategy[]): Promise<any>;
+}
 
-        commitOffset(commits: Commit | Commit[]): Promise<any>;
-        fetchOffset(commits: Commit | Commit[]): Promise<number[]>;
-
-        init(strategies?: Strategy | Strategy[]): Promise<any>;
+export interface GroupConsumerOptions {
+    /**
+      * groupId - group ID for comitting and fetching offsets.
+      * 
+      * Defaults to "no-kafka-group-v0.9"
+      */
+    groupId?: string;
+    /**
+      * maxWaitTime - maximum amount of time in milliseconds to 
+      * block waiting if insufficient data is available at the 
+      * time the fetch request is issued.
+      * 
+      * defaults to 100ms
+      */
+    maxWaitTime?: number;
+    /**
+      * idleTimeout - timeout between fetch calls.
+      * 
+      * defaults to 1000ms
+      */
+    idleTimeout?: number;
+    /**
+      * minBytes - minimum number of bytes to wait 
+      * from Kafka before returning the fetch call.
+      * 
+      * defaults to 1 byte
+      */
+    minBytes?: number;
+    /**
+      * maxBytes - maximum size of messages in a fetch response
+      */
+    maxBytes?: number;
+    /**
+      * clientId - ID of this client.
+      * 
+      * defaults to "no-kafka-client"
+      */
+    clientId?: string;
+    /**
+      * connectionString - comma delimited list of initial brokers list.
+      * 
+      * defaults to "127.0.0.1:9092"
+      */
+    connectionString?: string;
+    /**
+      * reconnectionDelay - controls optionally progressive
+      * delay between reconnection attempts in case of network error:
+      */
+    reconnectionDelay?: {
+    /**
+      * min - minimum delay, used as increment value for next attempts.
+      * 
+      * defaults to 1000ms
+      */
+    min?: number;
+    /**
+      * max - maximum delay value.
+      * 
+      * defaults to 1000ms
+      */
+    max?: number;
     }
+    /**
+      * sessionTimeout - session timeout in ms, min 6000, max 30000.
+      * 
+      * defaults to 15000
+      */
+    sessionTimeout?: number;
+    /**
+      * heartbeatTimeout - delay between heartbeat requests in ms.
+      * 
+      * defaults to 1000
+      */
+    heartbeatTimeout?: number;
+    /**
+      * retentionTime - offset retention time in ms.
+      * 
+      * defaults to 1 day (24 * 3600 * 1000)
+      */
+    retentionTime?: number;
+    /**
+      * startingOffset - starting position (time) when there is no commited offset.
+      * 
+      * defaults to Kafka.LATEST_OFFSET
+      */
+    startingOffset?: Kafka.OFFSET;
+    /**
+      * recoveryOffset - recovery position (time) which will 
+      * used to recover subscription in case of OffsetOutOfRange error.
+      * 
+      * defaults to Kafka.LATEST_OFFSET
+      */
+    recoveryOffset?: Kafka.OFFSET;
+    /**
+      * asyncCompression - boolean, use asynchronouse decompression 
+      * instead of synchronous.
+      * 
+      * defaults to false
+      */
+    asyncCompression?: boolean;
+    /**
+      * handlerConcurrency - specify concurrency level for the 
+      * consumer handler function.
+      * 
+      * defaults to 10
+      */
+    handlerConcurrency?: number;
+    /**
+      * connectionTimeout - timeout for establishing connection to Kafka in milliseconds
+      * 
+      * defaults to 3000ms
+      */
+    connectionTimeout?: number
+    /**
+      * socketTimeout - timeout for Kafka connection socket in milliseconds
+      * 
+      * defaults to 0 (disabled)
+      */
+    socketTimeout?: number
 
-    export interface GroupConsumerOptions {
-        /**
-         * groupId - group ID for comitting and fetching offsets.
-         * 
-         * Defaults to "no-kafka-group-v0.9"
-         */
-        groupId?: string;
-        /**
-         * maxWaitTime - maximum amount of time in milliseconds to 
-         * block waiting if insufficient data is available at the 
-         * time the fetch request is issued.
-         * 
-         * defaults to 100ms
-         */
-        maxWaitTime?: number;
-        /**
-         * idleTimeout - timeout between fetch calls.
-         * 
-         * defaults to 1000ms
-         */
-        idleTimeout?: number;
-        /**
-         * minBytes - minimum number of bytes to wait 
-         * from Kafka before returning the fetch call.
-         * 
-         * defaults to 1 byte
-         */
-        minBytes?: number;
-        /**
-         * maxBytes - maximum size of messages in a fetch response
-         */
-        maxBytes?: number;
-        /**
-         * clientId - ID of this client.
-         * 
-         * defaults to "no-kafka-client"
-         */
-        clientId?: string;
-        /**
-         * connectionString - comma delimited list of initial brokers list.
-         * 
-         * defaults to "127.0.0.1:9092"
-         */
-        connectionString?: string;
-        /**
-         * reconnectionDelay - controls optionally progressive
-         * delay between reconnection attempts in case of network error:
-         */
-        reconnectionDelay?: {
-        /**
-         * min - minimum delay, used as increment value for next attempts.
-         * 
-         * defaults to 1000ms
-         */
-        min?: number;
-        /**
-         * max - maximum delay value.
-         * 
-         * defaults to 1000ms
-         */
-        max?: number;
-        }
-        /**
-         * sessionTimeout - session timeout in ms, min 6000, max 30000.
-         * 
-         * defaults to 15000
-         */
-        sessionTimeout?: number;
-        /**
-         * heartbeatTimeout - delay between heartbeat requests in ms.
-         * 
-         * defaults to 1000
-         */
-        heartbeatTimeout?: number;
-        /**
-         * retentionTime - offset retention time in ms.
-         * 
-         * defaults to 1 day (24 * 3600 * 1000)
-         */
-        retentionTime?: number;
-        /**
-         * startingOffset - starting position (time) when there is no commited offset.
-         * 
-         * defaults to Kafka.LATEST_OFFSET
-         */
-        startingOffset?: Kafka.OFFSET;
-        /**
-         * recoveryOffset - recovery position (time) which will 
-         * used to recover subscription in case of OffsetOutOfRange error.
-         * 
-         * defaults to Kafka.LATEST_OFFSET
-         */
-        recoveryOffset?: Kafka.OFFSET;
-        /**
-         * asyncCompression - boolean, use asynchronouse decompression 
-         * instead of synchronous.
-         * 
-         * defaults to false
-         */
-        asyncCompression?: boolean;
-        /**
-         * handlerConcurrency - specify concurrency level for the 
-         * consumer handler function.
-         * 
-         * defaults to 10
-         */
-        handlerConcurrency?: number;
-        /**
-         * connectionTimeout - timeout for establishing connection to Kafka in milliseconds
-         * 
-         * defaults to 3000ms
-         */
-        connectionTimeout?: number
-        /**
-         * socketTimeout - timeout for Kafka connection socket in milliseconds
-         * 
-         * defaults to 0 (disabled)
-         */
-        socketTimeout?: number
+    brokerRedirection?: Kafka.BrokerRedirectionFunction | Kafka.BrokerRedirectionMap;
 
-        brokerRedirection?: Kafka.BrokerRedirectionFunction | Kafka.BrokerRedirectionMap;
+    logger?: Kafka.Logger;
+}
 
-        logger?: Kafka.Logger;
+export interface Strategy {
+    subscriptions?: string[];
+    handler?: DataHandler;
+    metadata?: {
+        id?: string;
+        weight?: number;
     }
-
-    export interface Commit {
-        topic?: string;
-        partition?: number;
-        offset?: number;
-        metadata?: string;
-    }
-
-    export interface Strategy {
-        subscriptions?: string[];
-        handler?: DataHandler;
-        metadata?: {
-            id?: string;
-            weight?: number;
-        }
-        strategy?: Kafka.AbstractAssignmentStrategy;
-    }
+    strategy?: Kafka.AbstractAssignmentStrategy;
+}
 
 
-    export interface DataHandler {
-        (messageSet: Kafka.Message[], topic: string, partition: number): Promise<any>;
-    }
+export interface DataHandler {
+    (messageSet: Kafka.Message[], topic: string, partition: number): Promise<any>;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,34 +1,10 @@
-/// <reference path="producer.d.ts" />
-/// <reference path="base_consumer.d.ts" />
-/// <reference path="simple_consumer.d.ts" />
-/// <reference path="group_consumer.d.ts" />
-/// <reference path="group_admin.d.ts" />
+export * from "./kafka";
+export * from "./client";
 
-/// <reference path="kafka.d.ts" />
-/// <reference path="client.d.ts" />
+export * from "./producer";
+export * from "./simple_consumer";
+export * from "./group_consumer";
 
-/// <reference path="assignment/partitioners/default.d.ts" />
-/// <reference path="assignment/partitioners/hash_crc32.d.ts" />
-/// <reference path="assignment/strategies/default.d.ts" />
-/// <reference path="assignment/strategies/consistent.d.ts" />
-/// <reference path="assignment/strategies/weighted_round_robin.d.ts" />
+export * from "./group_admin";
 
-declare module "no-kafka" {
-
-    export * from "kafka";
-    export * from "client";
-
-    export * from "producer";
-    export * from "simple_consumer";
-    export * from "group_consumer";
-
-    export * from "group_admin";
-
-    export { DefaultPartitioner } from "assignment/partitioners/default";
-    export { HashCRC32Partitioner } from "assignment/partitioners/hash_crc32";
-
-    export { DefaultAssignmentStrategy } from "assignment/strategies/default";
-    export { ConsistentAssignmentStrategy } from "assignment/strategies/consistent";
-    export { WeightedRoundRobinAssignmentStrategy } from "assignment/strategies/weighted_round_robin";
-
-}
+export * from "./assignment";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,11 +16,13 @@
 declare module "no-kafka" {
 
     export * from "kafka";
-    export { Producer, Result } from "producer";
-    export { SimpleConsumer } from "simple_consumer";
-    export { GroupConsumer } from "group_consumer";
+    export * from "client";
 
-    export { GroupAdmin } from "group_admin";
+    export * from "producer";
+    export * from "simple_consumer";
+    export * from "group_consumer";
+
+    export * from "group_admin";
 
     export { DefaultPartitioner } from "assignment/partitioners/default";
     export { HashCRC32Partitioner } from "assignment/partitioners/hash_crc32";

--- a/types/kafka.d.ts
+++ b/types/kafka.d.ts
@@ -1,84 +1,85 @@
+// offset request time constants
 
+export const EARLIEST_OFFSET = -2;
+export const LATEST_OFFSET = -1;
+export type OFFSET = -2 | -1;
 
-declare module "kafka" {
+// compression codecs
+export const COMPRESSION_SNAPPY = 2;
+export const COMPRESSION_GZIP = 1;
+export const COMPRESSION_NONE = 0;
+export type COMPRESSION = 0 | 1 | 2;
 
-    // offset request time constants
-
-    export const EARLIEST_OFFSET = -2;
-    export const LATEST_OFFSET = -1;
-    export type OFFSET = -2 | -1;
-
-    // compression codecs
-    export const COMPRESSION_SNAPPY = 2;
-    export const COMPRESSION_GZIP = 1;
-    export const COMPRESSION_NONE = 0;
-    export type COMPRESSION = 0 | 1 | 2;
-
-    export interface Message {
-        topic: string;
-        partition?: number;
-        offset?: number;
-        message: {
-            key?: string;
-            value: Buffer | string;
-            attributes?: string[];
-        }
+export interface Message {
+    topic: string;
+    partition?: number;
+    offset?: number;
+    message: {
+        key?: string;
+        value: Buffer | string;
+        attributes?: string[];
     }
+}
 
 
+/**
+  * A function returning a tuple of host (string) and port (integer), such as:
+
+brokerRedirection: function (host, port) {
+    return {
+        host: host + ".somesuffix.com", // Fully qualify
+        port: port + 100,               // Port NAT
+    }
+}
+  */
+export interface BrokerRedirectionFunction {
+    (host: string, port: number): { host: string; port: number };
+}
+
+/**
+  * A simple map of connection strings to new connection strings, such as:
+
+brokerRedirection: {
+    "some-host:9092": "actual-host:9092",
+    "kafka://another-host:9092": "another-host:9093",
+    "third-host:9092": "kafka://third-host:9000"
+}
+  */
+export type BrokerRedirectionMap = {};
+
+
+export interface AbstractAssignmentStrategy {
+}
+
+export { DefaultPartitioner } from "./assignment/partitioners/default";
+
+export interface Logger {
     /**
-     * A function returning a tuple of host (string) and port (integer), such as:
-    
-    brokerRedirection: function (host, port) {
-        return {
-            host: host + ".somesuffix.com", // Fully qualify
-            port: port + 100,               // Port NAT
-        }
-    }
-     */
-    export interface BrokerRedirectionFunction {
-        (host: string, port: number): { host: string; port: number };
-    }
-
+      * 0 - nothing, 1 - just errors, 2 - +warnings, 
+      * 3 - +info, 4 - +debug, 5 - +trace
+      */
+    logLevel?: 0 | 1 | 2 | 3 | 4 | 5;
     /**
-     * A simple map of connection strings to new connection strings, such as:
-    
-    brokerRedirection: {
-        "some-host:9092": "actual-host:9092",
-        "kafka://another-host:9092": "another-host:9093",
-        "third-host:9092": "kafka://third-host:9000"
+      * logstash: {
+        enabled: true,
+        connectionString: "10.0.1.1:9999,10.0.1.2:9999",
+        app: "myApp-kafka-consumer"
     }
-     */
-    export type BrokerRedirectionMap = {};
-
-
-    export interface AbstractAssignmentStrategy {
+      */
+    logstash?: {
+        enabled: boolean;
+        connectionString: string;
+        app: string;
     }
+    /**
+      * logFunction: console.log
+      */
+    logFunction?: any;
+}
 
-    export { DefaultPartitioner } from "assignment/partitioners/default";
-
-    export interface Logger {
-        /**
-         * 0 - nothing, 1 - just errors, 2 - +warnings, 
-         * 3 - +info, 4 - +debug, 5 - +trace
-         */
-        logLevel?: 0 | 1 | 2 | 3 | 4 | 5;
-        /**
-         * logstash: {
-            enabled: true,
-            connectionString: "10.0.1.1:9999,10.0.1.2:9999",
-            app: "myApp-kafka-consumer"
-        }
-         */
-        logstash?: {
-            enabled: boolean;
-            connectionString: string;
-            app: string;
-        }
-        /**
-         * logFunction: console.log
-         */
-        logFunction?: any;
-    }
-
+export interface Commit {
+    topic?: string;
+    partition?: number;
+    offset?: number;
+    metadata?: string;
 }

--- a/types/producer.d.ts
+++ b/types/producer.d.ts
@@ -273,7 +273,7 @@ declare module "producer" {
          * codec - compression codec, one of 
          *   Kafka.COMPRESSION_NONE, Kafka.COMPRESSION_SNAPPY, Kafka.COMPRESSION_GZIP
          */
-        codec: number; // Kafka.COMPRESSION_NONE | Kafka.COMPRESSION_SNAPPY | Kafka.COMPRESSION_GZIP;
+        codec?: number; // Kafka.COMPRESSION_NONE | Kafka.COMPRESSION_SNAPPY | Kafka.COMPRESSION_GZIP;
         /**
          * batch - control batching (grouping) of requests
          */

--- a/types/producer.d.ts
+++ b/types/producer.d.ts
@@ -1,304 +1,299 @@
+import * as tls from "tls";
+import * as Kafka from "./kafka";
+import { Client } from "./client";
 
+export class Producer {
+    constructor(options?: ProducerOptions);
+    /**
+      * Initializes the client for the producer.
+      * 
+      * @returns {Promise<Client>} 
+      * 
+      * @memberOf Producer
+      */
+    init(): Promise<Client>;
+    /**
+      * The send can take a single message or an array of messages.
+      * It can have options
+      * @memberOf Producer
+      */
+    send(data: Kafka.Message | Kafka.Message[], options?: SendOptions): Promise<Result[]>;
+    /**
+      * Close all connections.
+      */
+    end(): Promise<void>;
+}
 
-declare module "producer" {
-    import * as tls from "tls";
-    import * as Kafka from "kafka";
-    import { Client } from "client";
-    import { DefaultPartitioner } from "assignment/partitioners/default";
-
-    export class Producer {
-        constructor(options?: ProducerOptions);
+export interface ProducerOptions {
+    /**
+      * requiredAcks - require acknoledgments for produce request. 
+      * If it is 0 the server will not send any response. 
+      * If it is 1 (default), the server will wait the data 
+      * is written to the local log before sending a response.
+      * If it is -1 the server will block until the message is
+      * committed by all in sync replicas before sending a response.
+      * For any number > 1 the server will block waiting
+      * for this number of acknowledgements to occur
+      * (but the server will never wait for more acknowledgements
+      * than there are in-sync replicas).
+      * 
+      * default: 1
+      */
+    requiredAcks?: number;
+    /**
+      * timeout - timeout in ms for produce request
+      */
+    timeout?: number;
+    /**
+      * clientId - ID of this client.
+      * 
+      * defaults to "no-kafka-client"
+      */
+    clientId?: string;
+    /**
+      * connectionString - comma delimited list of initial brokers list.
+      * 
+      * default: "127.0.0.1:9092"
+      */
+    connectionString?: string;
+    /**
+      * reconnectionDelay - controls optionally progressive 
+      * delay between reconnection attempts in case of network error:
+      */
+    reconnectionDelay?: {
         /**
-         * Initializes the client for the producer.
-         * 
-         * @returns {Promise<Client>} 
-         * 
-         * @memberOf Producer
-         */
-        init(): Promise<Client>;
+          * min - minimum delay, used as increment value for next attempts.
+          * 
+          * defaults to 1000ms
+          */
+        min?: number;
         /**
-         * The send can take a single message or an array of messages.
-         * It can have options
-         * @memberOf Producer
-         */
-        send(data: Kafka.Message | Kafka.Message[], options?: SendOptions): Promise<Result[]>;
+          * max - maximum delay value.
+          * 
+          * defaults to 1000ms
+          */
+        max?: number;
+    }
+    /**
+      * partitioner - Class instance used to determine topic partition for message.
+      * If message already specifies a partition,
+      * the partitioner won't be used.
+      * The partitioner must inherit from Kafka.DefaultPartitioner.
+      */
+    partitioner?: Kafka.DefaultPartitioner;
+    /**
+      * retries - controls number of attempts at delay 
+      * between them when produce request fails
+      */
+    retries?: number;
+    /**
+      * attempts - number of total attempts to send the message.
+      * 
+      * defaults to 3
+      */
+    attempts?: number;
+    /**
+      * delay - controls delay between retries, 
+      * the delay is progressive and incrememented 
+      * with each attempt with min value steps up 
+      * to but not exceeding max value
+      */
+    delay?: {
         /**
-         * Close all connections.
-         */
-        end(): Promise<void>;
+          * min - minimum delay, used as increment value for next attempts.
+          * 
+          * defaults to 1000ms
+          */
+        min?: number;
+        /**
+          * max - maximum delay value.
+          * 
+          * defaults to 3000ms
+          */
+        max?: number;
     }
 
-    export interface ProducerOptions {
+    /**
+      * codec - compression codec.
+      */
+    codec?: Kafka.COMPRESSION;
+    /**
+      * batch - control batching (grouping) of requests
+      */
+    batch?: {
         /**
-         * requiredAcks - require acknoledgments for produce request. 
-         * If it is 0 the server will not send any response. 
-         * If it is 1 (default), the server will wait the data 
-         * is written to the local log before sending a response.
-         * If it is -1 the server will block until the message is
-         * committed by all in sync replicas before sending a response.
-         * For any number > 1 the server will block waiting
-         * for this number of acknowledgements to occur
-         * (but the server will never wait for more acknowledgements
-         * than there are in-sync replicas).
-         * 
-         * default: 1
-         */
-        requiredAcks?: number;
+          * size - group messages together into single batch 
+          * until their total size exceeds this value.
+          * Set to 0 to disable batching.
+          * 
+          * defaults to 16384 bytes.
+          */
+        size?: number;
         /**
-         * timeout - timeout in ms for produce request
-         */
-        timeout?: number;
+          * maxWait - send grouped messages after this
+          * amount of milliseconds expire even if their
+          * total size doesn't exceed batch.size yet.
+          * Set to 0 to disable batching.
+          * 
+          * defaults to 10ms.
+          */
+        maxWait?: number;
+    }
+    /**
+      * asyncCompression - boolean, use asynchronouse 
+      * compression instead of synchronous.
+      * 
+      * defaults to false
+      */
+    asyncCompression?: boolean;
+
+    /**
+      * To connect to Kafka with SSL endpoint enabled 
+      * specify SSL certificate and key options to 
+      * load cert/key from files or provide certificate/key 
+      * directly as strings.
+      * 
+      * Should match `listeners` SSL option in Kafka config
+      */
+    ssl?: tls.ConnectionOptions;
+    /**
+      * connectionTimeout - timeout for establishing connection to Kafka in milliseconds
+      * 
+      * defaults to 3000ms
+      */
+    connectionTimeout?: number
+    /**
+      * socketTimeout - timeout for Kafka connection socket in milliseconds
+      * 
+      * defaults to 0 (disabled)
+      */
+    socketTimeout?: number
+
+    brokerRedirection?: Kafka.BrokerRedirectionFunction | Kafka.BrokerRedirectionMap;
+
+    logger?: Kafka.Logger;
+}
+
+
+export interface Result {
+    topic: string;
+    partition: number;
+    offset: number;
+}
+
+export interface SendOptions {
+    /**
+      * requiredAcks - require acknoledgments for produce request. 
+      * If it is 0 the server will not send any response. 
+      * If it is 1, the server will wait the data is 
+      * written to the local log before sending a response. 
+      * If it is -1 the server will block until the message 
+      * is committed by all in sync replicas before sending a response. 
+      * For any number > 1 the server will block waiting for 
+      * this number of acknowledgements to occur 
+      * (but the server will never wait for more acknowledgements 
+      * than there are in-sync replicas).
+      * default: 1
+      */
+    requiredAcks?: number;
+    /** 
+      * timeout - timeout in ms for produce request
+      */
+    timeout?: number;
+    /**
+      * clientId - ID of this client
+      * default: 'no-kafka-client'
+      */
+    clientId?: string;
+    /**
+      * connectionString - comma delimited list of initial brokers list, 
+      * default: '127.0.0.1:9092'
+      */
+    connectionString?: string;
+    /**
+      * reconnectionDelay - controls optionally progressive 
+      * delay between reconnection attempts in case of network error:
+      */
+    reconnectionDelay?: {
         /**
-         * clientId - ID of this client.
-         * 
-         * defaults to "no-kafka-client"
-         */
-        clientId?: string;
+          * min - minimum delay, used as increment value for next attempts.
+          * default: 1000ms
+          */
+        min: number;
         /**
-         * connectionString - comma delimited list of initial brokers list.
-         * 
-         * default: "127.0.0.1:9092"
-         */
-        connectionString?: string;
+          * max - maximum delay value.
+          * default: 1000ms
+          */
+        max: number;
+    }
+    /**
+      * partitioner - Class instance used to determine topic partition for message.
+      * If message already specifies a partition, the partitioner won't be used.
+      * The partitioner must inherit from Kafka.DefaultPartitioner.
+      * The partition method receives 3 arguments: the topic name,
+      * an array with topic partitions, and the message (useful to partition by key, etc.).
+      * partition can be sync or async (return a Promise).
+      */
+    partitioner?: any;
+    /**
+      * retries - controls number of attempts at delay 
+      * between them when produce request fails
+      */
+    retries?: {
+
         /**
-         * reconnectionDelay - controls optionally progressive 
-         * delay between reconnection attempts in case of network error:
-         */
-        reconnectionDelay?: {
-            /**
-             * min - minimum delay, used as increment value for next attempts.
-             * 
-             * defaults to 1000ms
-             */
-            min?: number;
-            /**
-             * max - maximum delay value.
-             * 
-             * defaults to 1000ms
-             */
-            max?: number;
-        }
-        /**
-         * partitioner - Class instance used to determine topic partition for message.
-         * If message already specifies a partition,
-         * the partitioner won't be used.
-         * The partitioner must inherit from Kafka.DefaultPartitioner.
-         */
-        partitioner?: Kafka.DefaultPartitioner;
-        /**
-         * retries - controls number of attempts at delay 
-         * between them when produce request fails
-         */
-        retries?: number;
-        /**
-         * attempts - number of total attempts to send the message.
-         * 
-         * defaults to 3
-         */
+          * attempts - number of total attempts to send the message.
+          * default: 3
+          */
         attempts?: number;
         /**
-         * delay - controls delay between retries, 
-         * the delay is progressive and incrememented 
-         * with each attempt with min value steps up 
-         * to but not exceeding max value
-         */
+          * delay - controls delay between retries,
+          * the delay is progressive and incrememented
+          * with each attempt with min value steps up to but not exceeding max value
+          */
         delay?: {
             /**
-             * min - minimum delay, used as increment value for next attempts.
-             * 
-             * defaults to 1000ms
-             */
+              * min - minimum delay, used as increment value for next attempts.
+              * default: 1000ms
+              */
             min?: number;
             /**
-             * max - maximum delay value.
-             * 
-             * defaults to 3000ms
-             */
+              * max - maximum delay value.
+              * default: 3000ms
+              */
             max?: number;
         }
+    }
 
+    /**
+      * codec - compression codec, one of 
+      *   Kafka.COMPRESSION_NONE, Kafka.COMPRESSION_SNAPPY, Kafka.COMPRESSION_GZIP
+      */
+    codec?: number; // Kafka.COMPRESSION_NONE | Kafka.COMPRESSION_SNAPPY | Kafka.COMPRESSION_GZIP;
+    /**
+      * batch - control batching (grouping) of requests
+      */
+    batch?: {
         /**
-         * codec - compression codec.
-         */
-        codec?: Kafka.COMPRESSION;
+          * size - group messages together into single 
+          * batch until their total size exceeds this value.
+          * default: 16384 bytes.
+          * Set to 0 to disable batching.
+          */
+        size?: number;
         /**
-         * batch - control batching (grouping) of requests
-         */
-        batch?: {
-            /**
-             * size - group messages together into single batch 
-             * until their total size exceeds this value.
-             * Set to 0 to disable batching.
-             * 
-             * defaults to 16384 bytes.
-             */
-            size?: number;
-            /**
-             * maxWait - send grouped messages after this
-             * amount of milliseconds expire even if their
-             * total size doesn't exceed batch.size yet.
-             * Set to 0 to disable batching.
-             * 
-             * defaults to 10ms.
-             */
-            maxWait?: number;
-        }
+          * maxWait - send grouped messages after this amount of 
+          * milliseconds expire even if their total size 
+          * doesn't exceed batch.size yet.
+          * default: 10ms.
+          * Set to 0 to disable batching.
+          */
+        maxWait?: number;
         /**
-         * asyncCompression - boolean, use asynchronouse 
-         * compression instead of synchronous.
-         * 
-         * defaults to false
-         */
+          * asyncCompression - boolean, 
+          * use asynchronouse compression instead of synchronous.
+          * default: false
+          */
         asyncCompression?: boolean;
-
-        /**
-         * To connect to Kafka with SSL endpoint enabled 
-         * specify SSL certificate and key options to 
-         * load cert/key from files or provide certificate/key 
-         * directly as strings.
-         * 
-         * Should match `listeners` SSL option in Kafka config
-         */
-        ssl?: tls.ConnectionOptions;
-        /**
-         * connectionTimeout - timeout for establishing connection to Kafka in milliseconds
-         * 
-         * defaults to 3000ms
-         */
-        connectionTimeout?: number
-        /**
-         * socketTimeout - timeout for Kafka connection socket in milliseconds
-         * 
-         * defaults to 0 (disabled)
-         */
-        socketTimeout?: number
-
-        brokerRedirection?: Kafka.BrokerRedirectionFunction | Kafka.BrokerRedirectionMap;
-
-        logger?: Kafka.Logger;
-    }
-
-
-    export interface Result {
-        topic: string;
-        partition: number;
-        offset: number;
-    }
-
-    export interface SendOptions {
-        /**
-         * requiredAcks - require acknoledgments for produce request. 
-         * If it is 0 the server will not send any response. 
-         * If it is 1, the server will wait the data is 
-         * written to the local log before sending a response. 
-         * If it is -1 the server will block until the message 
-         * is committed by all in sync replicas before sending a response. 
-         * For any number > 1 the server will block waiting for 
-         * this number of acknowledgements to occur 
-         * (but the server will never wait for more acknowledgements 
-         * than there are in-sync replicas).
-         * default: 1
-         */
-        requiredAcks?: number;
-        /** 
-         * timeout - timeout in ms for produce request
-         */
-        timeout?: number;
-        /**
-         * clientId - ID of this client
-         * default: 'no-kafka-client'
-         */
-        clientId?: string;
-        /**
-         * connectionString - comma delimited list of initial brokers list, 
-         * default: '127.0.0.1:9092'
-         */
-        connectionString?: string;
-        /**
-         * reconnectionDelay - controls optionally progressive 
-         * delay between reconnection attempts in case of network error:
-         */
-        reconnectionDelay?: {
-            /**
-             * min - minimum delay, used as increment value for next attempts.
-             * default: 1000ms
-             */
-            min: number;
-            /**
-             * max - maximum delay value.
-             * default: 1000ms
-             */
-            max: number;
-        }
-        /**
-         * partitioner - Class instance used to determine topic partition for message.
-         * If message already specifies a partition, the partitioner won't be used.
-         * The partitioner must inherit from Kafka.DefaultPartitioner.
-         * The partition method receives 3 arguments: the topic name,
-         * an array with topic partitions, and the message (useful to partition by key, etc.).
-         * partition can be sync or async (return a Promise).
-         */
-        partitioner?: any;
-        /**
-         * retries - controls number of attempts at delay 
-         * between them when produce request fails
-         */
-        retries?: {
-
-            /**
-             * attempts - number of total attempts to send the message.
-             * default: 3
-             */
-            attempts?: number;
-            /**
-             * delay - controls delay between retries,
-             * the delay is progressive and incrememented
-             * with each attempt with min value steps up to but not exceeding max value
-             */
-            delay?: {
-                /**
-                 * min - minimum delay, used as increment value for next attempts.
-                 * default: 1000ms
-                 */
-                min?: number;
-                /**
-                 * max - maximum delay value.
-                 * default: 3000ms
-                 */
-                max?: number;
-            }
-        }
-
-        /**
-         * codec - compression codec, one of 
-         *   Kafka.COMPRESSION_NONE, Kafka.COMPRESSION_SNAPPY, Kafka.COMPRESSION_GZIP
-         */
-        codec?: number; // Kafka.COMPRESSION_NONE | Kafka.COMPRESSION_SNAPPY | Kafka.COMPRESSION_GZIP;
-        /**
-         * batch - control batching (grouping) of requests
-         */
-        batch?: {
-            /**
-             * size - group messages together into single 
-             * batch until their total size exceeds this value.
-             * default: 16384 bytes.
-             * Set to 0 to disable batching.
-             */
-            size?: number;
-            /**
-             * maxWait - send grouped messages after this amount of 
-             * milliseconds expire even if their total size 
-             * doesn't exceed batch.size yet.
-             * default: 10ms.
-             * Set to 0 to disable batching.
-             */
-            maxWait?: number;
-            /**
-             * asyncCompression - boolean, 
-             * use asynchronouse compression instead of synchronous.
-             * default: false
-             */
-            asyncCompression?: boolean;
-        }
     }
 }

--- a/types/simple_consumer.d.ts
+++ b/types/simple_consumer.d.ts
@@ -1,130 +1,115 @@
+import * as tls from 'tls';
+import * as Kafka from "./kafka";
+import { BaseConsumer } from "./base_consumer";
 
+export class SimpleConsumer extends BaseConsumer {
+    constructor(options?: SimpleConsumerOptions);
+    // commitOffset(commits: Commit[]): Promise<any>;
+    fetchOffset(commits: Kafka.Commit | Kafka.Commit[]): Promise<number[]>;  
+}
 
-declare module "simple_consumer" {
-    import * as tls from 'tls';
-    import * as Kafka from "kafka";
-    import { BaseConsumer } from "base_consumer";
-
-    export class SimpleConsumer extends BaseConsumer {
-        constructor(options?: SimpleConsumerOptions);
-        // commitOffset(commits: Commit[]): Promise<any>;
-        fetchOffset(commits: Commit | Commit[]): Promise<number[]>;  
+export interface SimpleConsumerOptions {
+    /**
+      * `groupId` - group ID for comitting and 
+      * fetching offsets. 
+      * Default: "no-kafka-group-v0"
+      */
+    groupId?: string;
+    /**
+      * `maxWaitTime` - maximum amount of time in 
+      * milliseconds to block waiting if insufficient 
+      * data is available at the time the fetch request is issued.
+      * 
+      * default: 100ms
+      */
+    maxWaitTime?: number;
+    /**
+      * `idleTimeout` - timeout between fetch calls.
+      * 
+      * default: 1000ms
+      */
+    idleTimeout?: number;
+    /**
+      * `minBytes` - minimum number of bytes to 
+      * wait from Kafka before returning the fetch call.
+      * 
+      * default: 1 byte
+      */
+    minBytes?: number;
+    /**
+      * `maxBytes` - maximum size of messages in a fetch response.
+      * 
+      * default: to 1MB
+      */
+    maxBytes?: number;
+    /**
+      * `clientId` - ID of this client.
+      * 
+      * default: "no-kafka-client"
+      */
+    clientId?: string;
+    /**
+      * `connectionString` - comma delimited list of initial brokers list.
+      * 
+      * default: "127.0.0.1:9092"
+      */
+    connectionString?: string;
+    /**
+      * `reconnectionDelay` - controls optionally progressive 
+      * delay between reconnection attempts in case of network error:
+      */
+    reconnectionDelay?: {
+        /**
+          * `min` - minimum delay, used as increment value 
+          * for next attempts.
+          * 
+          * defaults to 1000ms
+          */
+        min?: number;
+        /**
+          * `max` - maximum delay value.
+          * 
+          * defaults to 1000ms
+          */
+        max?: number;
     }
+    /**
+      * `recoveryOffset` - recovery position (time) which will used 
+      * to recover subscription in case of OffsetOutOfRange error.
+      * 
+      * defaults to Kafka.LATEST_OFFSET
+      */
+    recoveryOffset?: number;
+    /**
+      * `asyncCompression` - boolean, use asynchronouse decompression 
+      * instead of synchronous.
+      * 
+      * defaults to `false`
+      */
+    asyncCompression?: boolean;
+    /**
+      * `handlerConcurrency` - specify concurrency level 
+      * for the consumer handler function.
+      * 
+      * default: 10
+      */
+    handlerConcurrency?: number;
+    /**
+      * connectionTimeout - timeout for establishing connection to Kafka in milliseconds
+      * 
+      * defaults to 3000ms
+      */
+    connectionTimeout?: number
+    /**
+      * socketTimeout - timeout for Kafka connection socket in milliseconds
+      * 
+      * defaults to 0 (disabled)
+      */
+    socketTimeout?: number
 
-    export interface SimpleConsumerOptions {
-        /**
-         * `groupId` - group ID for comitting and 
-         * fetching offsets. 
-         * Default: "no-kafka-group-v0"
-         */
-        groupId?: string;
-        /**
-         * `maxWaitTime` - maximum amount of time in 
-         * milliseconds to block waiting if insufficient 
-         * data is available at the time the fetch request is issued.
-         * 
-         * default: 100ms
-         */
-        maxWaitTime?: number;
-        /**
-         * `idleTimeout` - timeout between fetch calls.
-         * 
-         * default: 1000ms
-         */
-        idleTimeout?: number;
-        /**
-         * `minBytes` - minimum number of bytes to 
-         * wait from Kafka before returning the fetch call.
-         * 
-         * default: 1 byte
-         */
-        minBytes?: number;
-        /**
-         * `maxBytes` - maximum size of messages in a fetch response.
-         * 
-         * default: to 1MB
-         */
-        maxBytes?: number;
-        /**
-         * `clientId` - ID of this client.
-         * 
-         * default: "no-kafka-client"
-         */
-        clientId?: string;
-        /**
-         * `connectionString` - comma delimited list of initial brokers list.
-         * 
-         * default: "127.0.0.1:9092"
-         */
-        connectionString?: string;
-        /**
-         * `reconnectionDelay` - controls optionally progressive 
-         * delay between reconnection attempts in case of network error:
-         */
-        reconnectionDelay?: {
-            /**
-             * `min` - minimum delay, used as increment value 
-             * for next attempts.
-             * 
-             * defaults to 1000ms
-             */
-            min?: number;
-            /**
-             * `max` - maximum delay value.
-             * 
-             * defaults to 1000ms
-             */
-            max?: number;
-        }
-        /**
-         * `recoveryOffset` - recovery position (time) which will used 
-         * to recover subscription in case of OffsetOutOfRange error.
-         * 
-         * defaults to Kafka.LATEST_OFFSET
-         */
-        recoveryOffset?: number;
-        /**
-         * `asyncCompression` - boolean, use asynchronouse decompression 
-         * instead of synchronous.
-         * 
-         * defaults to `false`
-         */
-        asyncCompression?: boolean;
-        /**
-         * `handlerConcurrency` - specify concurrency level 
-         * for the consumer handler function.
-         * 
-         * default: 10
-         */
-        handlerConcurrency?: number;
-        /**
-         * connectionTimeout - timeout for establishing connection to Kafka in milliseconds
-         * 
-         * defaults to 3000ms
-         */
-        connectionTimeout?: number
-        /**
-         * socketTimeout - timeout for Kafka connection socket in milliseconds
-         * 
-         * defaults to 0 (disabled)
-         */
-        socketTimeout?: number
+    brokerRedirection?: Kafka.BrokerRedirectionFunction | Kafka.BrokerRedirectionMap;
 
-        brokerRedirection?: Kafka.BrokerRedirectionFunction | Kafka.BrokerRedirectionMap;
+    ssl?: tls.ConnectionOptions;
 
-        ssl?: tls.ConnectionOptions;
-
-        logger?: Kafka.Logger;
-    }
-
-
-    export interface Commit {
-        topic?: string;
-        partition?: number;
-        offset?: number;
-        metadata?: string;
-    }
-
-
-    
+    logger?: Kafka.Logger;
 }


### PR DESCRIPTION
Using the `declare module "..."` syntax causes Typescript to export the declarations to the global namespace. This means if no-kafka is depended on by more than one library it will cause collisions as they both try to export the same global modules and the build will fail. For more details on this issue have a look at this [Typescript ticket](https://github.com/Microsoft/TypeScript/issues/12286). 

The fix is to use local module exports. This is technically the right way to provide types if you have access to the original module code (as we do). `declare module` should be reserved for providing types to a third-party module in which you don't have access to the source.

These declarations should be fully backward compatible.