### PR TITLE
Custom logger

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -39,7 +39,11 @@ function Client(options) {
         }
     });
 
-    logger = new Logger(self.options.logger);
+    if (typeof self.options.logger === 'function') {
+        logger = self.options.logger();
+    } else {
+        logger = new Logger(self.options.logger);
+    }
 
     // prepend clientId argument
     ['log', 'debug', 'error', 'warn', 'trace'].forEach(function (m) {


### PR DESCRIPTION
Adding ability to pass a custom logger implementation.

Rationale: many projects already have a logging implementation/infrastructure. This provides the ability for consumers to pass their own logging implementation instead of using the default `nice-simple-logger` logger.