### PR TITLE
Fix connection leak after metadata update

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -241,9 +241,17 @@ Client.prototype.updateMetadata = function () {
 
             _.each(response.broker, function (broker) {
                 var remapped = self.checkBrokerRedirect(broker.host, broker.port);
-                var connection = _.find(oldConnections, function (c, i) {
-                    return c.equal(remapped.host, remapped.port) && delete oldConnections[i];
+                var deleteKey = undefined;
+                var connection = _.find(oldConnections, function (c, key) {
+                    if (c.equal(remapped.host, remapped.port)) {
+                        deleteKey = key;
+                        return true;
+                    };
+                    return false;
                 });
+                if (deleteKey !== undefined) {
+                    delete oldConnections[deleteKey];
+                }
 
                 self.brokerConnections[broker.nodeId] = connection || self._createConnection(remapped.host, remapped.port);
             });


### PR DESCRIPTION
Prior to this patch whenever `updateMetadata()` was called and a valid connection was available, the connection would leak and another would be created. This is because the predicate passed to `_.find()` was deleting the connection from the `oldConnections` object before it was read by underscore.

An easy way to reproduce the leak is to use the `Producer` to send to a non-existent topic in a loop. This will cause `updateMetadata()` to be called for the failed message sends, leaking the Connection and 256KB underlying Buffer in the socket.