### PR TITLE
Leave retry loop after all attempts

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -274,6 +274,9 @@ Client.prototype.updateMetadata = function (topicNames) {
             if ((attempt - 1) % _.max([(60000 / delay), 1]) === 0) { // once per minute
                 self.error('Metadata request failed at attempt #' + attempt + '. Will keep trying. Error received was:', err);
             }
+            if (self.options.retries.attempts < attempt) {
+                throw new Error('Failed to connect to kafka after ' + attempt);
+            }
             attempt += 1;
             return Promise.delay(delay).then(_try);
         });


### PR DESCRIPTION
Current implementation of update meta data request does infinite amount of retries. 
This causes consumers to be stuck in retry cycle.
Need to break it after all retries