### PR TITLE
Kafka mnorkin/new promise for topics

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -225,9 +225,9 @@ Client.prototype.nextCorrelationId = function () {
 };
 
 Client.prototype.updateMetadata = function (topicNames) {
-    var self = this;
+    var self = this, updateMetadataPromise = Promise.resolve();
 
-    if (self._updateMetadata_running.isPending()) {
+    if (topicNames.length === 0 && self._updateMetadata_running.isPending()) {
         return self._updateMetadata_running;
     }
 
@@ -276,7 +276,12 @@ Client.prototype.updateMetadata = function (topicNames) {
         });
     }());
 
-    return self._updateMetadata_running;
+    if (topicNames.length === 0) {
+        self._updateMetadata_running = updateMetadataPromise;
+        return self._updateMetadata_running;
+    }
+
+    return updateMetadataPromise;
 };
 
 Client.prototype._waitMetadata = function () {


### PR DESCRIPTION
Currently the client does not support multiple publishers from the same instance. 

This is due to single promise on updateMetadata.

If two publishers publish on the same time, on initialization they both have no information in `self.topicMetadata`, so `updateMetadata` happens and the first publish will acquire the request, while the second will wait for the promise to resolve, thinking it's his promise. First publisher then receives promise resolve and tries to search in `self.topicMetadata` his topic and finds it. Second publisher also receives same promise, tries to search in  `self.topicMetadata` his topic and fails, because request was for the first publisher, not second.

This change introduces new promise for every updateMetadata request, then topics are involved. So no race condition happens. This race condition appeared in one of your tests.

@oleksiyk what do you think?